### PR TITLE
[DW-4033] Add s3 object tag condition to EMRFS IAM policy

### DIFF
--- a/terraform/deploy/app/modules.tf
+++ b/terraform/deploy/app/modules.tf
@@ -36,4 +36,5 @@ module "emr" {
   emrfs_kms_key_arns         = []
   # element[0] = bucket_name, element[1] = path (if required)
   dataset_s3_paths = [[data.terraform_remote_state.aws-analytical-dataset-generation.outputs.published_bucket.id, "*"]]
+  dataset_s3_tags = ["collection_tag", "crown"]
 }

--- a/terraform/deploy/app/modules.tf
+++ b/terraform/deploy/app/modules.tf
@@ -33,8 +33,7 @@ module "emr" {
   vpc                        = data.terraform_remote_state.aws_analytical_environment_infra.outputs.vpc
   env_certificate_bucket     = local.env_certificate_bucket
   emp_dir_path               = var.emp_dir_path
-  emrfs_kms_key_arns         = []
-  # element[0] = bucket_name, element[1] = path (if required)
+  emrfs_kms_key_arns         = [data.terraform_remote_state.aws-analytical-dataset-generation.outputs.published_bucket_cmk.arn]
   dataset_s3_paths = [[data.terraform_remote_state.aws-analytical-dataset-generation.outputs.published_bucket.id, "*"]]
   dataset_s3_tags  = ["collection_tag", "crown"]
 }

--- a/terraform/deploy/app/modules.tf
+++ b/terraform/deploy/app/modules.tf
@@ -34,6 +34,6 @@ module "emr" {
   env_certificate_bucket     = local.env_certificate_bucket
   emp_dir_path               = var.emp_dir_path
   emrfs_kms_key_arns         = [data.terraform_remote_state.aws-analytical-dataset-generation.outputs.published_bucket_cmk.arn]
-  dataset_s3_paths = [[data.terraform_remote_state.aws-analytical-dataset-generation.outputs.published_bucket.id, "*"]]
-  dataset_s3_tags  = ["collection_tag", "crown"]
+  dataset_s3_paths           = [[data.terraform_remote_state.aws-analytical-dataset-generation.outputs.published_bucket.id, "*"]]
+  dataset_s3_tags            = ["collection_tag", "crown"]
 }

--- a/terraform/deploy/app/modules.tf
+++ b/terraform/deploy/app/modules.tf
@@ -35,5 +35,5 @@ module "emr" {
   emp_dir_path               = var.emp_dir_path
   emrfs_kms_key_arns         = []
   # element[0] = bucket_name, element[1] = path (if required)
-  dataset_s3_paths           = [[data.terraform_remote_state.aws-analytical-dataset-generation.outputs.published_bucket.id, "*"]]
+  dataset_s3_paths = [[data.terraform_remote_state.aws-analytical-dataset-generation.outputs.published_bucket.id, "*"]]
 }

--- a/terraform/deploy/app/modules.tf
+++ b/terraform/deploy/app/modules.tf
@@ -36,5 +36,5 @@ module "emr" {
   emrfs_kms_key_arns         = []
   # element[0] = bucket_name, element[1] = path (if required)
   dataset_s3_paths = [[data.terraform_remote_state.aws-analytical-dataset-generation.outputs.published_bucket.id, "*"]]
-  dataset_s3_tags = ["collection_tag", "crown"]
+  dataset_s3_tags  = ["collection_tag", "crown"]
 }

--- a/terraform/deploy/app/modules.tf
+++ b/terraform/deploy/app/modules.tf
@@ -33,6 +33,7 @@ module "emr" {
   vpc                        = data.terraform_remote_state.aws_analytical_environment_infra.outputs.vpc
   env_certificate_bucket     = local.env_certificate_bucket
   emp_dir_path               = var.emp_dir_path
-  dataset_s3_paths           = []
   emrfs_kms_key_arns         = []
+  # element[0] = bucket_name, element[1] = path (if required)
+  dataset_s3_paths           = [[data.terraform_remote_state.aws-analytical-dataset-generation.outputs.published_bucket.id, "*"]]
 }

--- a/terraform/deploy/app/terraform.tf.j2
+++ b/terraform/deploy/app/terraform.tf.j2
@@ -89,6 +89,20 @@ data "terraform_remote_state" "certificate_authority" {
   }
 }
 
+data "terraform_remote_state" "aws-analytical-dataset-generation" {
+  backend   = "s3"
+  workspace = local.management_workspace[local.management_account[local.environment]]
+
+  config = {
+    bucket         = "{{state_file_bucket}}"
+    key            = "terraform/dataworks/aws-analytical-dataset-generation.tfstate"
+    region         = "{{state_file_region}}"
+    encrypt        = true
+    kms_key_id     = "arn:aws:kms:{{state_file_region}}:{{state_file_account}}:key/{{state_file_kms_key}}"
+    dynamodb_table = "remote_state_locks"
+  }
+}
+
 provider "aws" {
   alias  = "management"
   region = var.region

--- a/terraform/modules/emr/emrfs_iam.tf
+++ b/terraform/modules/emr/emrfs_iam.tf
@@ -51,9 +51,18 @@ data "aws_iam_policy_document" "emrfs_iam" {
       ],
       [
         for path_tuple in var.dataset_s3_paths :
-        format("arn:aws:s3:::%s/*", path_tuple[0])
+        format("arn:aws:s3:::%s/%s", path_tuple[0], path_tuple[1])
       ],
       var.emrfs_kms_key_arns
     )
+
+    condition {
+      test     = "StringEquals"
+      variable = "s3:ExistingObjectTag/collection_tag"
+
+      values = [
+        "crown"
+      ]
+    }
   }
 }

--- a/terraform/modules/emr/emrfs_iam.tf
+++ b/terraform/modules/emr/emrfs_iam.tf
@@ -58,10 +58,10 @@ data "aws_iam_policy_document" "emrfs_iam" {
 
     condition {
       test     = "StringEquals"
-      variable = "s3:ExistingObjectTag/collection_tag"
+      variable = format("s3:ExistingObjectTag/%s", var.dataset_s3_tags[0])
 
       values = [
-        "crown"
+        var.dataset_s3_tags[1]
       ]
     }
   }

--- a/terraform/modules/emr/variables.tf
+++ b/terraform/modules/emr/variables.tf
@@ -104,4 +104,9 @@ variable "dataset_s3_paths" {
   description = "List of [bucket_name, bucket_path] tuples that emrfs users can access"
 }
 
+variable "dataset_s3_tags" {
+  type        = tuple([string, string])
+  description = "Tuple of [tag_key, tag_value] that determine which s3 objects emrfs can access"
+}
+
 variable "cognito_user_pool_id" {}


### PR DESCRIPTION
* get the name of the dataset_generation bucket from remote_state
* grant EMRFS access to that bucket via IAM policy
* add condition to EMRFS IAM policy to restrict S3 object access to only those objects that contain the tag `collection_tag: crown`
