### PR TITLE
Remove tag from resource

### DIFF
--- a/ci/aws-analytical-env/jobs/pr.yml
+++ b/ci/aws-analytical-env/jobs/pr.yml
@@ -61,7 +61,6 @@ jobs:
           path: aws-analytical-env
           status: pending
       - get: custom-auth-lambda-release
-        version: { tag: '0.0.20' }
         trigger: true
       - .: (( inject meta.plan.terraform-bootstrap ))
         params:


### PR DESCRIPTION
* as noted in other PRs of similar nature, the github-release resource doesn't deal with versions that don't begin with `v` very well. 