### PR TITLE
[DW-4347] Add Costcode and Team tags

### DIFF
--- a/ci/aws-analytical-env/shared/meta.yml
+++ b/ci/aws-analytical-env/shared/meta.yml
@@ -58,9 +58,6 @@ meta:
         inputs:
           - name: aws-analytical-env
           - name: terraform-config
-      params:
-        TF_CLI_ARGS_apply: -lock-timeout=300s
-        TF_INPUT: "false"
 
     terraform-plan:
       task: terraform-plan
@@ -79,9 +76,6 @@ meta:
         inputs:
           - name: aws-analytical-env
           - name: terraform-config
-      params:
-        TF_CLI_ARGS_plan: -lock-timeout=300s -detailed-exitcode
-        TF_INPUT: "false"
 
     terraform-output-app:
       task: terraform-output-app
@@ -103,9 +97,6 @@ meta:
           - name: terraform-config
         outputs:
           - name: terraform-output-app
-      params:
-        TF_CLI_ARGS_plan: -lock-timeout=300s
-        TF_INPUT: "false"
 
     analytical-env-e2e-tests:
       task: analytical-env-e2e-tests
@@ -153,6 +144,3 @@ meta:
         inputs:
           - name: aws-analytical-env
           - name: terraform-config
-      params:
-        TF_CLI_ARGS_plan: -lock-timeout=300s -detailed-exitcode
-        TF_INPUT: "false"

--- a/ci/aws-analytical-env/shared/meta.yml
+++ b/ci/aws-analytical-env/shared/meta.yml
@@ -12,6 +12,7 @@ meta:
           TF_INPUT: false
           TF_CLI_ARGS_apply: -lock-timeout=300s
           TF_CLI_ARGS_plan: -lock-timeout=300s
+          TF_VAR_costcode: ((dataworks.costcode))
 
     terraform-bootstrap:
       task: terraform-bootstrap

--- a/terraform/deploy/app/terraform.tf.j2
+++ b/terraform/deploy/app/terraform.tf.j2
@@ -215,7 +215,7 @@ locals {
     Application  = local.name
     Persistence  = "True"
     AutoShutdown = "False"
-    Costcode     = "{{dataworks_costcode}}"
+    Costcode     = "{{var.costcode}}"
     Team         = "DataWorks"
   }
 

--- a/terraform/deploy/app/terraform.tf.j2
+++ b/terraform/deploy/app/terraform.tf.j2
@@ -215,7 +215,7 @@ locals {
     Application  = local.name
     Persistence  = "True"
     AutoShutdown = "False"
-    Costcode     = "{{var.costcode}}"
+    Costcode     = var.costcode
     Team         = "DataWorks"
   }
 

--- a/terraform/deploy/app/terraform.tf.j2
+++ b/terraform/deploy/app/terraform.tf.j2
@@ -215,6 +215,8 @@ locals {
     Application  = local.name
     Persistence  = "True"
     AutoShutdown = "False"
+    Costcode     = "{{dataworks_costcode}}"
+    Team         = "DataWorks"
   }
 
 }

--- a/terraform/deploy/app/variables.tf
+++ b/terraform/deploy/app/variables.tf
@@ -7,3 +7,8 @@ variable "region" {
   type    = string
   default = "eu-west-2"
 }
+
+variable "costcode" {
+  type    = string
+  default = ""
+}

--- a/terraform/deploy/cognito/terraform.tf.j2
+++ b/terraform/deploy/cognito/terraform.tf.j2
@@ -106,7 +106,7 @@ locals {
     Application  = local.name
     Persistence  = "True"
     AutoShutdown = "False"
-    Costcode     = "{{var.costcode}}"
+    Costcode     = var.costcode
     Team         = "DataWorks"
   }
 

--- a/terraform/deploy/cognito/terraform.tf.j2
+++ b/terraform/deploy/cognito/terraform.tf.j2
@@ -106,6 +106,8 @@ locals {
     Application  = local.name
     Persistence  = "True"
     AutoShutdown = "False"
+    Costcode     = "{{dataworks_costcode}}"
+    Team         = "DataWorks"
   }
 
   cidr_block = {

--- a/terraform/deploy/cognito/terraform.tf.j2
+++ b/terraform/deploy/cognito/terraform.tf.j2
@@ -106,7 +106,7 @@ locals {
     Application  = local.name
     Persistence  = "True"
     AutoShutdown = "False"
-    Costcode     = "{{dataworks_costcode}}"
+    Costcode     = "{{var.costcode}}"
     Team         = "DataWorks"
   }
 

--- a/terraform/deploy/cognito/variables.tf
+++ b/terraform/deploy/cognito/variables.tf
@@ -22,3 +22,8 @@ variable "name_prefix" {
 variable "onboarding_email_file_path" {
   description = "(Required) File path to onboarding email template"
 }
+
+variable "costcode" {
+  type    = string
+  default = ""
+}

--- a/terraform/deploy/infra/terraform.tf.j2
+++ b/terraform/deploy/infra/terraform.tf.j2
@@ -132,7 +132,7 @@ locals {
     Application  = local.name
     Persistence  = "Ignore"
     AutoShutdown = "False"
-    Costcode     = "{{dataworks_costcode}}"
+    Costcode     = "{{var.costcode}}"
     Team         = "DataWorks"
   }
 

--- a/terraform/deploy/infra/terraform.tf.j2
+++ b/terraform/deploy/infra/terraform.tf.j2
@@ -132,6 +132,8 @@ locals {
     Application  = local.name
     Persistence  = "Ignore"
     AutoShutdown = "False"
+    Costcode     = "{{dataworks_costcode}}"
+    Team         = "DataWorks"
   }
 
   cidr_block = {

--- a/terraform/deploy/infra/terraform.tf.j2
+++ b/terraform/deploy/infra/terraform.tf.j2
@@ -132,7 +132,7 @@ locals {
     Application  = local.name
     Persistence  = "Ignore"
     AutoShutdown = "False"
-    Costcode     = "{{var.costcode}}"
+    Costcode     = var.costcode
     Team         = "DataWorks"
   }
 

--- a/terraform/deploy/infra/variables.tf
+++ b/terraform/deploy/infra/variables.tf
@@ -8,3 +8,7 @@ variable "region" {
   default = "eu-west-2"
 }
 
+variable "costcode" {
+  type    = string
+  default = ""
+}


### PR DESCRIPTION
The costcode is a required tag according to - http://docs.dwpcloud.uk/services/aws-account-prod.html#cost-reporting
Also adding a team tag, to help track costs across team resources. 