### PR TITLE
Add midnight trigger to all EMR clusters

### DIFF
--- a/ci/aws-analytical-env/jobs/taint/dev.yml
+++ b/ci/aws-analytical-env/jobs/taint/dev.yml
@@ -1,6 +1,8 @@
 jobs:
   - name: taint-dev
     plan:
+      - get: midnight-trigger
+        trigger: true
       - get: aws-analytical-env
         trigger: false
       - .: (( inject meta.plan.terraform-bootstrap ))

--- a/ci/aws-analytical-env/jobs/taint/int.yml
+++ b/ci/aws-analytical-env/jobs/taint/int.yml
@@ -1,6 +1,8 @@
 jobs:
   - name: taint-int
     plan:
+      - get: midnight-trigger
+        trigger: true
       - get: aws-analytical-env
         trigger: false
       - .: (( inject meta.plan.terraform-bootstrap ))

--- a/ci/aws-analytical-env/jobs/taint/preprod.yml
+++ b/ci/aws-analytical-env/jobs/taint/preprod.yml
@@ -1,6 +1,8 @@
 jobs:
   - name: taint-preprod
     plan:
+      - get: midnight-trigger
+        trigger: true
       - get: aws-analytical-env
         trigger: false
       - .: (( inject meta.plan.terraform-bootstrap ))

--- a/ci/aws-analytical-env/jobs/taint/qa.yml
+++ b/ci/aws-analytical-env/jobs/taint/qa.yml
@@ -1,6 +1,8 @@
 jobs:
   - name: taint-qa
     plan:
+      - get: midnight-trigger
+        trigger: true
       - get: aws-analytical-env
         trigger: false
       - .: (( inject meta.plan.terraform-bootstrap ))


### PR DESCRIPTION
At the moment only the EMR cluster in Prod is recycled at midnight. 
This action/schedule should be taking place in all environments, to increase visibility and stop production from being an outlier. 

For clarity - the EMR cluster is recycled nightly to run bootstrap actions which load new users and any other changes made to Cognito/auth.