### PR TITLE
[DW-4352] Use event rather than environment variables to allow invoke from behave

### DIFF
--- a/terraform/modules/testing/rbac_test_lambda_files/rbac_lambda.py
+++ b/terraform/modules/testing/rbac_test_lambda_files/rbac_lambda.py
@@ -113,11 +113,11 @@ def check_for_access_denied(session_url, pii_table_name):
     elif response['output']['status'] == "error":
         kill_session(session_url)
         print(response['output']['evalue'])
-        sys.exit('Excepted 403 - But received a different error')
+        sys.exit('Expected 403 - But received a different error')
     else:
         kill_session(session_url)
         print(response['output']['evalue'])
-        sys.exit('Excepted 403 - But did not receive access denied')
+        sys.exit('Expected 403 - But did not receive access denied')
 
 
 # Attempt to access a table with the pii:false tag - should be successful
@@ -134,4 +134,4 @@ def check_for_access_granted(session_url, non_pii_table_name):
     else:
         kill_session(session_url)
         print(response['output']['evalue'])
-        sys.exit('Excepted data - Received an error')
+        sys.exit('Expected data - Received an error')

--- a/terraform/modules/testing/rbac_test_lambda_files/tests/test_lambda.py
+++ b/terraform/modules/testing/rbac_test_lambda_files/tests/test_lambda.py
@@ -6,6 +6,11 @@ import urllib3
 
 host = "http://test_host.com:8998"
 sessions_url = host + "/sessions"
+proxy_user = "test_user"
+non_pii_table_name = "test_non_pii_table"
+pii_table_name = "test_pii_table"
+database_name = "test_database"
+
 
 @patch('rbac_lambda.urllib3.PoolManager.request')
 class TestRbac(TestCase):
@@ -71,7 +76,7 @@ class TestRbac(TestCase):
         ]
         mock_check.side_effect = mock_response
         expected = "OK"
-        actual = rbac_lambda.check_for_access_denied(sessions_url)
+        actual = rbac_lambda.check_for_access_denied(sessions_url, pii_table_name)
         assert expected == actual
 
 
@@ -99,7 +104,7 @@ class TestRbac(TestCase):
         ]
         mock_check.side_effect = mock_response
         with self.assertRaises(SystemExit):
-            rbac_lambda.check_for_access_denied(sessions_url)
+            rbac_lambda.check_for_access_denied(sessions_url, pii_table_name)
 
     # Expected: 200
     # Actual : 200
@@ -124,7 +129,7 @@ class TestRbac(TestCase):
             )
         ]
         mock_check.side_effect = mock_response
-        actual = rbac_lambda.check_for_access_granted(sessions_url)
+        actual = rbac_lambda.check_for_access_granted(sessions_url, non_pii_table_name)
         expected = "OK"
         assert expected == actual
 
@@ -152,4 +157,4 @@ class TestRbac(TestCase):
         ]
         mock_check.side_effect = mock_response
         with self.assertRaises(SystemExit):
-            rbac_lambda.check_for_access_granted(sessions_url)
+            rbac_lambda.check_for_access_granted(sessions_url, non_pii_table_name)


### PR DESCRIPTION
Change the way we read the variables passed in.
**Before**
Using environment variables
**Now**
Read parameters from invocation event/context. 
Allows the lambda to be invoked by behave, and to pass variables in at runtime