### PR TITLE
Update RBAC lambda tests with user access specifically identified

### DIFF
--- a/terraform/modules/testing/rbac_test_lambda_files/rbac_lambda.py
+++ b/terraform/modules/testing/rbac_test_lambda_files/rbac_lambda.py
@@ -127,6 +127,11 @@ def check_access_is_correct(session_url, table, access):
             kill_session(session_url)
             print("Expected 403 - received 403")
             return "OK"
+        # Should receive 403 when trying to access data - but didn't. Throw error.
+        elif table["type"] == "pii" and response['output']['status'] != "error":
+            kill_session(session_url)
+            print(response['output']['evalue'])
+            sys.exit('Expected 403 - Received data')
         # Error - exit and print error
         elif response['output']['status'] == "error":
             kill_session(session_url)

--- a/terraform/modules/testing/rbac_test_lambda_files/rbac_lambda.py
+++ b/terraform/modules/testing/rbac_test_lambda_files/rbac_lambda.py
@@ -17,14 +17,13 @@ def lambda_handler(context, event):
 
     print("CONTEXT: ", context)
     proxy_user = context["proxy_user"] if "proxy_user" in context else "test_user"
-    non_pii_table_name = context["non_pii_table"] if "non_pii_table" in context else "test_non_pii_table"
-    pii_table_name = context["pii_table"] if "pii_table" in context else "test_pii_table"
+    table = context["table"] if "table" in context else {"name": "test_table", "type": "pii"}
+    access = context["user_access"] if "access" in context else {"non_pii"}
     database_name = context["db_name"] if "db_name" in context else "test_database"
 
     session_url = start_session(proxy_user)
     use_database(session_url, database_name)
-    check_for_access_denied(session_url, pii_table_name)
-    check_for_access_granted(session_url, non_pii_table_name)
+    check_access_is_correct(session_url, table, access)
     kill_session(session_url)
 
 def initial_request(url, code):
@@ -97,41 +96,44 @@ def use_database(session_url, database_name):
     print(response)
     print("Using Database", database_name)
 
+
 #############
 # Test RBAC #
 #############
-# Attempt to access a table with the pii:true tag - should receive 403 error
-def check_for_access_denied(session_url, pii_table_name):
-    print("Attempting to access PII data")
+def check_access_is_correct(session_url, table, access):
     statements_url = session_url + '/statements'
-    code = {'code': f'spark.sql("select * from {pii_table_name}")'}
-    status_url = initial_request(statements_url, code)
-    response = poll_for_result(session_url, status_url)
-    if access_denied_message in response['output']['evalue']:
-        print("Expected 403 - Got 403")
-        return "OK"
-    elif response['output']['status'] == "error":
-        kill_session(session_url)
-        print(response['output']['evalue'])
-        sys.exit('Expected 403 - But received a different error')
-    else:
-        kill_session(session_url)
-        print(response['output']['evalue'])
-        sys.exit('Expected 403 - But did not receive access denied')
-
-
-# Attempt to access a table with the pii:false tag - should be successful
-def check_for_access_granted(session_url, non_pii_table_name):
-    print("Attempting to access Non PII data")
-    statements_url = session_url + '/statements'
-    code = {'code': f'spark.sql("select * from {non_pii_table_name}")'}
+    code = {'code': f'spark.sql("select * from {table["name"]}")'}
     status_url = initial_request(statements_url, code)
     response = poll_for_result(session_url, status_url)
     print(response)
-    if response['output']['status'] != "error":
-        print("Expected no error - No error found")
-        return "OK"
-    else:
-        kill_session(session_url)
-        print(response['output']['evalue'])
-        sys.exit('Expected data - Received an error')
+
+    # Should have full access to all data
+    if access == "pii":
+        # Error - exit and print error
+        if response['output']['status'] == "error":
+            kill_session(session_url)
+            print(response['output']['evalue'])
+            sys.exit('Expected data - Received data')
+        # Received data as expected
+        else:
+            kill_session(session_url)
+            print("Expected data - Received data")
+            return "OK"
+
+    # Should only have access to non-pii data
+    if access == "non_pii":
+        # Should receive 403 when trying to access pii data
+        if table["type"] == "pii" and access_denied_message in response['output']['evalue']:
+            kill_session(session_url)
+            print("Expected 403 - received 403")
+            return "OK"
+        # Error - exit and print error
+        elif response['output']['status'] == "error":
+            kill_session(session_url)
+            print("error")
+            print(response['output']['status'])
+        # Finally, if no error, then non-pii data was returned as expected
+        else:
+            kill_session(session_url)
+            print("Expected data - Received data")
+            return "OK"

--- a/terraform/modules/testing/rbac_test_lambda_files/rbac_lambda.py
+++ b/terraform/modules/testing/rbac_test_lambda_files/rbac_lambda.py
@@ -113,7 +113,7 @@ def check_access_is_correct(session_url, table, access):
         if response['output']['status'] == "error":
             kill_session(session_url)
             print(response['output']['evalue'])
-            sys.exit('Expected data - Received error')
+            raise Exception('Expected data - Received error')
         # Received data as expected
         else:
             kill_session(session_url)
@@ -131,12 +131,12 @@ def check_access_is_correct(session_url, table, access):
         elif table["type"] == "pii" and response['output']['status'] != "error":
             kill_session(session_url)
             print(response['output']['evalue'])
-            sys.exit('Expected 403 - Received data')
+            raise Exception('Expected 403 - Received data')
         # Error - exit and print error
         elif response['output']['status'] == "error":
             kill_session(session_url)
             print(response['output']['evalue'])
-            sys.exit('Expected data - Received error')
+            raise Exception('Expected data - Received error')
         # Finally, if no error, then non-pii data was returned as expected
         else:
             kill_session(session_url)

--- a/terraform/modules/testing/rbac_test_lambda_files/rbac_lambda.py
+++ b/terraform/modules/testing/rbac_test_lambda_files/rbac_lambda.py
@@ -113,7 +113,7 @@ def check_access_is_correct(session_url, table, access):
         if response['output']['status'] == "error":
             kill_session(session_url)
             print(response['output']['evalue'])
-            sys.exit('Expected data - Received data')
+            sys.exit('Expected data - Received error')
         # Received data as expected
         else:
             kill_session(session_url)
@@ -130,8 +130,8 @@ def check_access_is_correct(session_url, table, access):
         # Error - exit and print error
         elif response['output']['status'] == "error":
             kill_session(session_url)
-            print("error")
-            print(response['output']['status'])
+            print(response['output']['evalue'])
+            sys.exit('Expected data - Received error')
         # Finally, if no error, then non-pii data was returned as expected
         else:
             kill_session(session_url)

--- a/terraform/modules/testing/rbac_test_lambda_files/rbac_lambda.py
+++ b/terraform/modules/testing/rbac_test_lambda_files/rbac_lambda.py
@@ -16,10 +16,10 @@ def lambda_handler(context, event):
     # kill_all_sessions()
 
     print("CONTEXT: ", context)
-    proxy_user = context["proxy_user"] if "proxy_user" in context else "test_user"
-    table = context["table"] if "table" in context else {"name": "test_table", "type": "pii"}
-    access = context["user_access"] if "access" in context else {"non_pii"}
-    database_name = context["db_name"] if "db_name" in context else "test_database"
+    proxy_user = context["proxy_user"]
+    table = context["table"]
+    access = context["user_access"]
+    database_name = context["db_name"]
 
     session_url = start_session(proxy_user)
     use_database(session_url, database_name)

--- a/terraform/modules/testing/rbac_test_lambda_files/tests/test_lambda.py
+++ b/terraform/modules/testing/rbac_test_lambda_files/tests/test_lambda.py
@@ -89,7 +89,7 @@ class TestNonPiiTable(TestCase):
     # Excepted: 200
     # Actual : 200
     def test_check_for_access_granted_to_non_pii_as_pii_user(self, mock_check):
-        print("\nStart test access granted to non-PII table as non-PII user\n")
+        print("\nStart test access granted to non-PII table as PII user\n")
 
         access = "pii"
         table = {"name": "test_table_non_pii", "type": "non_pii"}

--- a/terraform/modules/testing/rbac_test_lambda_files/tests/test_lambda.py
+++ b/terraform/modules/testing/rbac_test_lambda_files/tests/test_lambda.py
@@ -7,20 +7,17 @@ import urllib3
 host = "http://test_host.com:8998"
 sessions_url = host + "/sessions"
 proxy_user = "test_user"
-non_pii_table_name = "test_non_pii_table"
-pii_table_name = "test_pii_table"
 database_name = "test_database"
 
-
 @patch('rbac_lambda.urllib3.PoolManager.request')
-class TestRbac(TestCase):
+class TestSessionSetup(TestCase):
     # Expected: One request, creates session and returns session url
     def test_inital_request(self, mock_post):
         print("\nStart test_initial_request\n")
 
         code = {
             'kind': 'spark',
-            'proxyUser': 'test_user'
+            'proxyUser': proxy_user
         }
         mock_response = urllib3.response.HTTPResponse(
             body=b'{"id":0,"proxyUser":"testuser017","state":"starting","kind":"spark"}',
@@ -55,61 +52,17 @@ class TestRbac(TestCase):
         assert response["state"] == "idle"
         assert mock_get.call_count == 3
 
-    # Excepted: 403
-    # Actual : 403
-    def test_check_for_access_denied(self, mock_check):
-        print("\nStart test_check_403_returned\n")
-        mock_response = [
-            urllib3.response.HTTPResponse(
-                body=b'{"id":0,"proxyUser":"testuser017","state":"starting","kind":"spark"}',
-                status=200,
-                headers={
-                    "location": "/sessions/1/statements/1"
-                }
-            ),
-            urllib3.response.HTTPResponse(
-                body=b'{"id":0,"proxyUser":"testuser017","state":"waiting","kind":"spark"}',
-            ),
-            urllib3.response.HTTPResponse(
-                body=b'{"id":0,"proxyUser":"testuser017","state":"available","kind":"spark","output":{"status":"error","evalue":"Service: Amazon S3; Status Code: 403; Error Code: AccessDenied"}}'
-            ),
-        ]
-        mock_check.side_effect = mock_response
-        expected = "OK"
-        actual = rbac_lambda.check_for_access_denied(sessions_url, pii_table_name)
-        assert expected == actual
 
-
-    # Excepted: 403
-    # Actual : Not 403
-    def test_check_for_access_not_denied(self, mock_check):
-        print("\nStart test_check_when_403_isnt_returned\n")
-        mock_response = [
-            urllib3.response.HTTPResponse(
-                body=b'{"id":0,"proxyUser":"testuser017","state":"starting","kind":"spark"}',
-                status=200,
-                headers={
-                    "location": "/sessions/1/statements/1"
-                }
-            ),
-            urllib3.response.HTTPResponse(
-                body=b'{"id":0,"proxyUser":"testuser017","state":"waiting","kind":"spark"}',
-            ),
-            urllib3.response.HTTPResponse(
-                body=b'{"id":0,"proxyUser":"testuser017","state":"available","kind":"spark","output":{"status":"ok","evalue":"Data"}}'
-            ),
-            urllib3.response.HTTPResponse(
-                body=b'"SessionKilled'
-            )
-        ]
-        mock_check.side_effect = mock_response
-        with self.assertRaises(SystemExit):
-            rbac_lambda.check_for_access_denied(sessions_url, pii_table_name)
-
+@patch('rbac_lambda.urllib3.PoolManager.request')
+class TestNonPiiTable(TestCase):
     # Expected: 200
     # Actual : 200
-    def test_check_for_access_granted(self, mock_check):
-        print("\nStart test_check_when_403_isnt_returned\n")
+    def test_check_for_access_granted_to_non_pii_as_non_pii(self, mock_check):
+        print("\nStart test access granted to non-PII table as non-PII user\n")
+
+        access = "non_pii"
+        table = {"name": "test_table_non_pii", "type": "non_pii"}
+
         mock_response = [
             urllib3.response.HTTPResponse(
                 body=b'{"id":0,"proxyUser":"testuser017","state":"starting","kind":"spark"}',
@@ -129,14 +82,52 @@ class TestRbac(TestCase):
             )
         ]
         mock_check.side_effect = mock_response
-        actual = rbac_lambda.check_for_access_granted(sessions_url, non_pii_table_name)
+        actual = rbac_lambda.check_access_is_correct(sessions_url, table, access)
         expected = "OK"
         assert expected == actual
 
     # Excepted: 200
-    # Actual : 403
-    def test_check_for_access_granted_error(self, mock_check):
-        print("\nStart test_check_403_returned\n")
+    # Actual : 200
+    def test_check_for_access_granted_to_non_pii_as_pii_user(self, mock_check):
+        print("\nStart test access granted to non-PII table as non-PII user\n")
+
+        access = "pii"
+        table = {"name": "test_table_non_pii", "type": "non_pii"}
+
+        mock_response = [
+            urllib3.response.HTTPResponse(
+                body=b'{"id":0,"proxyUser":"testuser017","state":"starting","kind":"spark"}',
+                status=200,
+                headers={
+                    "location": "/sessions/1/statements/1"
+                }
+            ),
+            urllib3.response.HTTPResponse(
+                body=b'{"id":0,"proxyUser":"testuser017","state":"waiting","kind":"spark"}',
+            ),
+            urllib3.response.HTTPResponse(
+                body=b'{"id":0,"proxyUser":"testuser017","state":"available","kind":"spark","output":{"status":"ok","evalue":"Data"}}'
+            ),
+            urllib3.response.HTTPResponse(
+                body=b'"SessionKilled'
+            )
+        ]
+        mock_check.side_effect = mock_response
+        actual = rbac_lambda.check_access_is_correct(sessions_url, table, access)
+        expected = "OK"
+        assert expected == actual
+
+
+@patch('rbac_lambda.urllib3.PoolManager.request')
+class TestPiiTable(TestCase):
+    # Expected 403
+    # Actual 200
+    def test_check_for_access_denied_to_pii_as_non_pii_user(self, mock_check):
+        print("\nStart check for access denied to PII table as non-PII user\n")
+
+        table = {"name": "test_table_pii", "type": "pii"}
+        access = "non_pii"
+
         mock_response = [
             urllib3.response.HTTPResponse(
                 body=b'{"id":0,"proxyUser":"testuser017","state":"starting","kind":"spark"}',
@@ -156,5 +147,37 @@ class TestRbac(TestCase):
             )
         ]
         mock_check.side_effect = mock_response
-        with self.assertRaises(SystemExit):
-            rbac_lambda.check_for_access_granted(sessions_url, non_pii_table_name)
+        expected = "OK"
+        actual = rbac_lambda.check_access_is_correct(sessions_url, table, access)
+        assert expected == actual
+
+    # Excepted: 200
+    # Actual : 200
+    def test_check_for_access_granted_to_pii_as_pii(self, mock_check):
+        print("\nStart check for access granted to PII table as PII user\n")
+
+        table = {"name": "test_table_pii", "type": "pii"}
+        access = "pii"
+
+        mock_response = [
+            urllib3.response.HTTPResponse(
+                body=b'{"id":0,"proxyUser":"testuser017","state":"starting","kind":"spark"}',
+                status=200,
+                headers={
+                    "location": "/sessions/1/statements/1"
+                }
+            ),
+            urllib3.response.HTTPResponse(
+                body=b'{"id":0,"proxyUser":"testuser017","state":"waiting","kind":"spark"}',
+            ),
+            urllib3.response.HTTPResponse(
+                body=b'{"id":0,"proxyUser":"testuser017","state":"available","kind":"spark","output":{"status":"ok","evalue":"Data"}}'
+            ),
+            urllib3.response.HTTPResponse(
+                body=b'"SessionKilled'
+            )
+        ]
+        mock_check.side_effect = mock_response
+        actual = rbac_lambda.check_access_is_correct(sessions_url, table, access)
+        expected = "OK"
+        assert expected == actual


### PR DESCRIPTION
* If parameters aren't in context, then fail - rather than setting defaults

* Specify user access level to enable clearer tests. pii user should have all access, whereas non-pii user should only have access to non-pii data 
* Allow one function to test all access, rather than 1 per level. 
* Implement table "type" - pii or non_pii

* Result is based on logic gates rather than multiple functions