### PR TITLE
switching e2e to run run-ci.sh now that it is receiving the correct variables

### DIFF
--- a/ci/aws-analytical-env/shared/meta.yml
+++ b/ci/aws-analytical-env/shared/meta.yml
@@ -120,12 +120,12 @@ meta:
           args:
             - -exc
             - |
-              cd src/runners
-              ./run-dev-analytical-tests.sh
+              ./src/runners/run-ci.sh "" "" "" "" "" "../terraform-output-analytical-dataset-generation"
         inputs:
           - name: aws-dataworks-e2e-framework
           - name: .aws
           - name: meta
+          - name: terraform-output-analytical-dataset-generation
 
     terraform-taint:
       task: terraform-taint


### PR DESCRIPTION
The e2e tests were set to be running the version of the script intended for local development work. It has now been switched to use the dynamically filled script that other repos use and has the correct environment variable passed in at runtime.