### PR TITLE
[DW 4383] adding pen test ips and checks for prod environment

### DIFF
--- a/terraform/deploy/infra/terraform.tf.j2
+++ b/terraform/deploy/infra/terraform.tf.j2
@@ -149,10 +149,12 @@ locals {
     {% for cidr in doiranges %}
     "{{ cidr }}",
     {% endfor %}
+    {% if pen is defined %}
     {% set penranges = pen["cidr_blocks"].split(',') %}
     {% for cidr in penranges %}
     "{{ cidr }}",
     {% endfor %}
+    {% endif %}
     "{{ucfs["team_cidr_block"]}}"
   ]
 }

--- a/terraform/deploy/infra/terraform.tf.j2
+++ b/terraform/deploy/infra/terraform.tf.j2
@@ -143,8 +143,9 @@ locals {
           {{ key }} = "{{ value }}"{% endfor %}
       } {% endfor %}
   }
-  
-  whitelist_cidr_blocks = [
+
+
+  whitelist_cidr_blocks =  local.environment == "integration"? [
     {% set doiranges = doi["cidr_blocks"].split(',') %}
     {% for cidr in doiranges %}
     "{{ cidr }}",
@@ -156,5 +157,12 @@ locals {
     {% endfor %}
     {% endif %}
     "{{ucfs["team_cidr_block"]}}"
+  ] : [
+    {% set doiranges = doi["cidr_blocks"].split(',') %}
+    {% for cidr in doiranges %}
+    "{{ cidr }}",
+    {% endfor %}
+    "{{ucfs["team_cidr_block"]}}"
   ]
+
 }

--- a/terraform/deploy/infra/terraform.tf.j2
+++ b/terraform/deploy/infra/terraform.tf.j2
@@ -148,7 +148,11 @@ locals {
     {% set doiranges = doi["cidr_blocks"].split(',') %}
     {% for cidr in doiranges %}
     "{{ cidr }}",
-    {% endfor %} 
+    {% endfor %}
+    {% set penranges = pen["cidr_blocks"].split(',') %}
+    {% for cidr in penranges %}
+    "{{ cidr }}",
+    {% endfor %}
     "{{ucfs["team_cidr_block"]}}"
   ]
 }


### PR DESCRIPTION
The IPs stated in the ticket: (DW-4383[https://projects.ucd.gpn.gov.uk/browse/DW-4383](url)) have been added in mgmt-dev for Int but not mgmt account
