### PR TITLE
[DW-4459] Remove version from encryption provider filename

### DIFF
--- a/terraform/modules/emr/configuration_security.tf
+++ b/terraform/modules/emr/configuration_security.tf
@@ -7,7 +7,7 @@ locals {
       AtRestEncryptionConfiguration = {
         S3EncryptionConfiguration = {
           EncryptionMode             = "CSE-Custom"
-          S3Object                   = "s3://${var.artefact_bucket.id}/emr-encryption-materials-provider/encryption-materials-provider-0.0.7-all.jar"
+          S3Object                   = "s3://${var.artefact_bucket.id}/emr-encryption-materials-provider/encryption-materials-provider-all.jar"
           EncryptionKeyProviderClass = "uk.gov.dwp.dataworks.dks.encryptionmaterialsprovider.DKSEncryptionMaterialsProvider"
         }
         LocalDiskEncryptionConfiguration = {


### PR DESCRIPTION
As the encryption provider jar no longer has its version in its filename (now as a S3 tag) we need to point our EMR security configuration at that file instead. 

The latest version will always have this filename - while older versions will be available from github releases (or possibly in the same s3 bucket?)
