### PR TITLE
[DW-4351] Add application-autoscaling:DescribeScalableTargets permission to EMR IAM

### DIFF
--- a/terraform/modules/emr/iam.tf
+++ b/terraform/modules/emr/iam.tf
@@ -61,6 +61,7 @@ data "aws_iam_policy_document" "elastic_map_reduce_role" {
       "ec2:RunInstances",
       "ec2:DescribeVolumeStatus",
       "ec2:DescribeVolumes",
+      "application-autoscaling:DescribeScalableTargets"
     ]
     # Majority of these actions don't accept conditions or resource restriction
     resources = ["*"]


### PR DESCRIPTION
The AE_EMR_Role didn't have permission to `DescribeScalableTargets` so was throwing Access Denied errors at midnight during our taint and recreate scheduled job.

In order to remove these errors, and reduce alerts, we have added that permission (even though it wasn't needed for the taint/recreate job to succeed) 