### PR TITLE
Add DeleteNetworkInterface permission to AE_EMR_Role

### DIFF
--- a/terraform/modules/emr/iam.tf
+++ b/terraform/modules/emr/iam.tf
@@ -61,7 +61,8 @@ data "aws_iam_policy_document" "elastic_map_reduce_role" {
       "ec2:RunInstances",
       "ec2:DescribeVolumeStatus",
       "ec2:DescribeVolumes",
-      "application-autoscaling:DescribeScalableTargets"
+      "application-autoscaling:DescribeScalableTargets",
+      "ec2:DeleteNetworkInterface",
     ]
     # Majority of these actions don't accept conditions or resource restriction
     resources = ["*"]
@@ -74,7 +75,6 @@ data "aws_iam_policy_document" "elastic_map_reduce_role" {
       "ec2:DetachVolume",
       "ec2:DeleteVolume",
       "ec2:RevokeSecurityGroupEgress",
-      "ec2:DeleteNetworkInterface",
       "ec2:DeleteSecurityGroup",
       "ec2:DeleteTags",
       "ec2:DetachNetworkInterface",


### PR DESCRIPTION
Each night at midnight, the AE_EMR_Role attempts to cycle the EMR cluster - we are getting alerts for Access Denied. 


* Moving DeleteNetworkInterfaces permission under the "*" resource condition
* This is because the Network Interfaces created by the EMR cluster are not tagged with our common tags meaning the role doesn't have permission to delete them
* Moving the permission does not pose a risk, as a Network Interface can only be deleted when it is not in use/attached. Therefore in use ENIs are protected from accidental deletion.