### PR TITLE
Dw 4571 amending iam fixing proxy issues correcting pii tag

### DIFF
--- a/ci/aws-analytical-env/shared/meta.yml
+++ b/ci/aws-analytical-env/shared/meta.yml
@@ -130,11 +130,11 @@ meta:
               [profile default]
               role_arn = arn:aws:iam::((dataworks.aws_dev_acc)):role/ci
               credential_source = Ec2InstanceMetadata
+              region = ((dataworks.aws_region))
               EOF
               cd src/runners
-              unset HTTP_PROXY HTTPS_PROXY http_proxy https_proxy
-              export AWS_PUBLISHED_BUCKET=manual-cr-test-can-be-deleted
-              ./run-ci.sh "../../../meta" "" "" "" "" ""
+              export no_proxy="$no_proxy,s3.*.amazonaws.com,s3.amazonaws.com"
+              ./run-ci.sh "../../../meta" "" "" "" "" "../terraform-ouput-analytical-dataset-generation"
         inputs:
           - name: aws-dataworks-e2e-framework
           - name: meta

--- a/terraform/modules/emr/emrfs_iam.tf
+++ b/terraform/modules/emr/emrfs_iam.tf
@@ -29,11 +29,6 @@ resource "aws_iam_role_policy_attachment" "AnalyticalDatasetReadOnly" {
   policy_arn = "arn:aws:iam::${var.account}:policy/AnalyticalDatasetCrownReadOnly"
 }
 
-resource "aws_iam_role_policy_attachment" "AnalyticalDatasetReadOnlyNonPii" {
-  role       = aws_iam_role.emrfs_iam_non_pii.name
-  policy_arn = "arn:aws:iam::${var.account}:policy/AnalyticalDatasetCrownReadOnly"
-}
-
 resource "aws_iam_role_policy" "emrfs_iam" {
   name   = "emrfs_iam"
   role   = aws_iam_role.emrfs_iam.id
@@ -69,9 +64,36 @@ data "aws_iam_policy_document" "emrfs_iam_non_pii" {
     resources = [
       "*"
     ]
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "s3:GetBucketLocation",
+      "s3:ListBucket",
+    ]
+
+    resources = [
+      "${var.dataset_s3_paths[0]}/analytical-dataset/*",
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "s3:Get*",
+      "s3:List*",
+    ]
+
+    resources = [
+      "${var.dataset_s3_paths[0]}/analytical-dataset/*",
+    ]
+
     condition {
       test     = "StringEquals"
-      variable = "s3:ExistingObjectTag/pii"
+      variable = "s3:ExistingObjectTag/Pii"
 
       values = [
         "false"

--- a/terraform/modules/emr/emrfs_iam.tf
+++ b/terraform/modules/emr/emrfs_iam.tf
@@ -29,6 +29,11 @@ resource "aws_iam_role_policy_attachment" "AnalyticalDatasetReadOnly" {
   policy_arn = "arn:aws:iam::${var.account}:policy/AnalyticalDatasetCrownReadOnly"
 }
 
+resource "aws_iam_role_policy_attachment" "AnalyticalDatasetReadOnlyNonPii" {
+  role       = aws_iam_role.emrfs_iam_non_pii.name
+  policy_arn = "arn:aws:iam::${var.account}:policy/AnalyticalDatasetCrownReadOnlyNonPii"
+}
+
 resource "aws_iam_role_policy" "emrfs_iam" {
   name   = "emrfs_iam"
   role   = aws_iam_role.emrfs_iam.id
@@ -38,7 +43,7 @@ resource "aws_iam_role_policy" "emrfs_iam" {
 resource "aws_iam_role_policy" "emrfs_iam_non_pii" {
   name   = "emrfs_iam_non_pii"
   role   = aws_iam_role.emrfs_iam_non_pii.id
-  policy = data.aws_iam_policy_document.emrfs_iam_non_pii.json
+  policy = data.aws_iam_policy_document.emrfs_iam.json
 }
 
 data "aws_iam_policy_document" "emrfs_iam" {
@@ -51,53 +56,5 @@ data "aws_iam_policy_document" "emrfs_iam" {
     resources = [
       "*"
     ]
-  }
-}
-
-data "aws_iam_policy_document" "emrfs_iam_non_pii" {
-  statement {
-    sid    = "AllowAllDynamoDB"
-    effect = "Allow"
-    actions = [
-      "dynamodb:*",
-    ]
-    resources = [
-      "*"
-    ]
-  }
-
-  statement {
-    effect = "Allow"
-
-    actions = [
-      "s3:GetBucketLocation",
-      "s3:ListBucket",
-    ]
-
-    resources = [
-      "${var.dataset_s3_paths[0]}/analytical-dataset/*",
-    ]
-  }
-
-  statement {
-    effect = "Allow"
-
-    actions = [
-      "s3:Get*",
-      "s3:List*",
-    ]
-
-    resources = [
-      "${var.dataset_s3_paths[0]}/analytical-dataset/*",
-    ]
-
-    condition {
-      test     = "StringEquals"
-      variable = "s3:ExistingObjectTag/Pii"
-
-      values = [
-        "false"
-      ]
-    }
   }
 }


### PR DESCRIPTION
Fixing the remaining issues that were found through the e2e tests:

 * Setting up an IAM role that only allows access to data tagged with `Pii : false`
 * Passing in region as there is no default region in AWS Concourse (as there is in Crown)
 * Switching to the policy that allows access to all data tagged {{collection_tag: crown}} to one that allows access to all data tagged {{collection_tag: crown}} but restricts to `Pii : false`