### PR TITLE
DW-4709 Use preferred name for ADFS users on EMR

### DIFF
--- a/terraform/modules/emr/templates/emr/setup.sh
+++ b/terraform/modules/emr/templates/emr/setup.sh
@@ -42,7 +42,7 @@ for GROUP in $${COGNITO_GROUPS[@]}; do
   sudo groupadd -f "$GROUP"
 
   echo "Adding users for group $GROUP"
-  USERS=$(aws cognito-idp list-users-in-group --user-pool-id "${user_pool_id}" --group-name "$GROUP" | jq '.Users[]' | jq -r '(.Attributes[] | if .Name =="preferred_username" then .Value else empty end) // .[].Username')
+  USERS=$(aws cognito-idp list-users-in-group --user-pool-id "${user_pool_id}" --group-name "$GROUP" | jq '.Users[]' | jq -r '(.Attributes[] | if .Name =="preferred_username" then .Value else empty end) // .Username')
 
   USERDIR=$(aws cognito-idp list-users --user-pool-id "${user_pool_id}")
 

--- a/terraform/modules/emr/templates/emr/setup.sh
+++ b/terraform/modules/emr/templates/emr/setup.sh
@@ -42,7 +42,6 @@ for GROUP in $${COGNITO_GROUPS[@]}; do
   sudo groupadd -f "$GROUP"
 
   echo "Adding users for group $GROUP"
-#  USERS=$(aws cognito-idp list-users-in-group --user-pool-id "${user_pool_id}" --group-name "$GROUP" | jq '.Users' | jq -r '.[].Username')
   USERS=$(aws cognito-idp list-users-in-group --user-pool-id "${user_pool_id}" --group-name "$GROUP" | jq '.Users[]' | jq -r '(.Attributes[] | if .Name =="preferred_username" then .Value else empty end) // .[].Username')
 
   USERDIR=$(aws cognito-idp list-users --user-pool-id "${user_pool_id}")


### PR DESCRIPTION
The default username for ADFS users contains values that don't work with UNIX usernames (such as @ ) - so we are using their "preferred username" value instead. 