### PR TITLE
[DW-4794] Use PUSH rather than PUT for metrics

### DIFF
--- a/terraform/modules/testing/metrics_lambda_files/metrics_lambda.py
+++ b/terraform/modules/testing/metrics_lambda_files/metrics_lambda.py
@@ -138,9 +138,10 @@ def publish_metrics_to_cw(metric_name, metric_value):
 def push_metrics_to_pushgateway(name, value):
     print(f"Pushing metric {name} to Prometheus push gateway")
     pushgateway_url = f"https://{push_host}:{push_port}/metrics/job/analytical-env-emr-metrics/instance/livy"
-    data = f"analytical_env_{name} {value}\n"
+    data = f"# TYPE analytical_env_{name} gauge\n" \
+           f"analytical_env_{name} {value}\n"
     response = http.request(
-        "PUT",
+        "POST",
         pushgateway_url,
         body=data,
         headers={'Content-Type': 'text/plain'}


### PR DESCRIPTION
* Using PUT method overwrites any metrics already pushed
* Using PUSH will only overwrite identical metrics (with the same name)


`POST method
POST works exactly like the PUT method but only metrics with the same name as the newly pushed metrics are replaced (among those with the same grouping key).`