### PR TITLE
Fix Concourse PR status check name to align with GitHub context

### DIFF
--- a/ci/aws-analytical-env/jobs/pr.yml
+++ b/ci/aws-analytical-env/jobs/pr.yml
@@ -10,7 +10,6 @@ jobs:
       - put: aws-analytical-env
         resource: aws-analytical-env-pr
         params:
-          context: $BUILD_JOB_NAME
           path: aws-analytical-env
           status: pending
       - .: (( inject meta.plan.terraform-bootstrap ))
@@ -51,14 +50,12 @@ jobs:
           put: aws-analytical-env
           resource: aws-analytical-env-pr
           params:
-            context: $BUILD_JOB_NAME
             path: aws-analytical-env
             status: failure
         on_success:
           put: aws-analytical-env
           resource: aws-analytical-env-pr
           params:
-            context: $BUILD_JOB_NAME
             path: aws-analytical-env
             status: success
   - name: pull-request_cognito
@@ -71,7 +68,6 @@ jobs:
       - put: aws-analytical-env
         resource: aws-analytical-env-pr
         params:
-          context: $BUILD_JOB_NAME
           path: aws-analytical-env
           status: pending
       - get: custom-auth-lambda-release
@@ -96,13 +92,11 @@ jobs:
           put: aws-analytical-env
           resource: aws-analytical-env-pr
           params:
-            context: $BUILD_JOB_NAME
             path: aws-analytical-env
             status: failure
         on_success:
           put: aws-analytical-env
           resource: aws-analytical-env-pr
           params:
-            context: $BUILD_JOB_NAME
             path: aws-analytical-env
             status: success


### PR DESCRIPTION
Concourse no longer interpolates BUILD_JOB_NAME, so remote it so
that statuses get posted back to GitHub with the correct context
of concourse-ci/status.