### PR TITLE
Dw 5295 mapping users to user iam roles

### DIFF
--- a/ci/aws-analytical-env/shared/meta.yml
+++ b/ci/aws-analytical-env/shared/meta.yml
@@ -51,7 +51,7 @@ meta:
             - |
               apk add --update --no-cache python3 && ln -sf python3 /usr/bin/python
               python3 -m ensurepip
-              pip3 install --no-cache --upgrade pip setuptools boto3 sys json math
+              pip3 install --no-cache --upgrade pip setuptools boto3
               cp ../../../../terraform-config/terraform.tf .
               cp ../../../../terraform-config/terraform.tfvars .
               terraform workspace show

--- a/ci/aws-analytical-env/shared/meta.yml
+++ b/ci/aws-analytical-env/shared/meta.yml
@@ -49,6 +49,7 @@ meta:
           args:
             - -exc
             - |
+              apk add --update --no-cache python3 && ln -sf python3 /usr/bin/python
               cp ../../../../terraform-config/terraform.tf .
               cp ../../../../terraform-config/terraform.tfvars .
               terraform workspace show
@@ -70,6 +71,7 @@ meta:
           args:
             - -exc
             - |
+              apk add --update --no-cache python3 && ln -sf python3 /usr/bin/python
               cp ../../../../terraform-config/terraform.tf .
               cp ../../../../terraform-config/terraform.tfvars .
               terraform workspace show

--- a/ci/aws-analytical-env/shared/meta.yml
+++ b/ci/aws-analytical-env/shared/meta.yml
@@ -50,6 +50,8 @@ meta:
             - -exc
             - |
               apk add --update --no-cache python3 && ln -sf python3 /usr/bin/python
+              python3 -m ensurepip
+              pip3 install --no-cache --upgrade pip setuptools boto3 sys json math
               cp ../../../../terraform-config/terraform.tf .
               cp ../../../../terraform-config/terraform.tfvars .
               terraform workspace show
@@ -72,6 +74,8 @@ meta:
             - -exc
             - |
               apk add --update --no-cache python3 && ln -sf python3 /usr/bin/python
+              python3 -m ensurepip
+              pip3 install --no-cache --upgrade pip setuptools boto3
               cp ../../../../terraform-config/terraform.tf .
               cp ../../../../terraform-config/terraform.tfvars .
               terraform workspace show

--- a/terraform/deploy/app/modules.tf
+++ b/terraform/deploy/app/modules.tf
@@ -180,21 +180,29 @@ module "rbac_db" {
   name_prefix = "analytical-env-rbac"
 
   config_bucket = {
-    id      = data.terraform_remote_state.common.outputs.config_bucket.id
+    id = data.terraform_remote_state.common.outputs.config_bucket.id
     cmk_arn = data.terraform_remote_state.common.outputs.config_bucket_cmk.arn
   }
   init_db_sql_path = "${path.module}/rbac-db-init.ddl.sql"
 
-  vpc_id               = data.terraform_remote_state.aws_analytical_environment_infra.outputs.vpc.aws_vpc.id
-  subnet_ids           = data.terraform_remote_state.aws_analytical_environment_infra.outputs.vpc.aws_subnets_private[*].id
+  vpc_id = data.terraform_remote_state.aws_analytical_environment_infra.outputs.vpc.aws_vpc.id
+  subnet_ids = data.terraform_remote_state.aws_analytical_environment_infra.outputs.vpc.aws_subnets_private[*].id
   interface_vpce_sg_id = data.terraform_remote_state.aws_analytical_environment_infra.outputs.interface_vpce_sg_id
 
 
   manage_mysql_user_lambda_zip = {
     base_path = var.manage_mysql_user_lambda_zip.base_path
-    version   = var.manage_mysql_user_lambda_zip.version
+    version = var.manage_mysql_user_lambda_zip.version
   }
 
   common_tags = local.common_tags
+}
 
+module "data" {
+  source = "../../modules/data_user_roles"
+  user_pool_id = data.terraform_remote_state.cognito.outputs.cognito.user_pool_id
+}
+
+output "data" {
+  value = module.data.output
 }

--- a/terraform/deploy/app/modules.tf
+++ b/terraform/deploy/app/modules.tf
@@ -2,7 +2,7 @@ module "emr_ami" {
   source = "../../modules/amis"
 
   providers = {
-    aws = aws.management
+    aws = aws.management-ami
   }
 
   ami_filter_name   = "name"
@@ -47,9 +47,10 @@ module "emr" {
     UC_DataScience_PII     = ["HiveDataUCDataSciencePII", "AnalyticalDatasetCrownReadOnly", "ReadPDMPiiAndNonPii"],
     UC_DataScience_Non_PII = ["HiveDataUCDataScienceNonPII", "AnalyticalDatasetCrownReadOnlyNonPii", "ReadPDMNonPiiOnly"]
   }
-  monitoring_sns_topic_arn = data.terraform_remote_state.security-tools.outputs.sns_topic_london_monitoring.arn
-  logging_bucket           = data.terraform_remote_state.security-tools.outputs.logstore_bucket.id
-  name_prefix              = local.name
+  security_configuration_user_roles = module.user_roles.output.users
+  monitoring_sns_topic_arn          = data.terraform_remote_state.security-tools.outputs.sns_topic_london_monitoring.arn
+  logging_bucket                    = data.terraform_remote_state.security-tools.outputs.logstore_bucket.id
+  name_prefix                       = local.name
 
 
   use_mysql_hive_metastore     = local.use_mysql_hive_metastore[local.environment]
@@ -174,6 +175,7 @@ module "emrfs_lambda" {
   internet_proxy_sg_id       = data.terraform_remote_state.aws_analytical_environment_infra.outputs.internet_proxy_sg
 }
 
+<<<<<<< HEAD
 module "rbac_db" {
   source = "../../modules/aurora_db"
 
@@ -198,11 +200,15 @@ module "rbac_db" {
   common_tags = local.common_tags
 }
 
-module "data" {
-  source = "../../modules/data_user_roles"
+module "user_roles" {
+  source       = "../../modules/data_user_roles"
   user_pool_id = data.terraform_remote_state.cognito.outputs.cognito.user_pool_id
+
+  providers = {
+    aws = aws.management
+  }
 }
 
 output "data" {
-  value = module.data.output
+  value = module.user_roles.output
 }

--- a/terraform/deploy/app/modules.tf
+++ b/terraform/deploy/app/modules.tf
@@ -181,19 +181,19 @@ module "rbac_db" {
   name_prefix = "analytical-env-rbac"
 
   config_bucket = {
-    id = data.terraform_remote_state.common.outputs.config_bucket.id
+    id      = data.terraform_remote_state.common.outputs.config_bucket.id
     cmk_arn = data.terraform_remote_state.common.outputs.config_bucket_cmk.arn
   }
   init_db_sql_path = "${path.module}/rbac-db-init.ddl.sql"
 
-  vpc_id = data.terraform_remote_state.aws_analytical_environment_infra.outputs.vpc.aws_vpc.id
-  subnet_ids = data.terraform_remote_state.aws_analytical_environment_infra.outputs.vpc.aws_subnets_private[*].id
+  vpc_id               = data.terraform_remote_state.aws_analytical_environment_infra.outputs.vpc.aws_vpc.id
+  subnet_ids           = data.terraform_remote_state.aws_analytical_environment_infra.outputs.vpc.aws_subnets_private[*].id
   interface_vpce_sg_id = data.terraform_remote_state.aws_analytical_environment_infra.outputs.interface_vpce_sg_id
 
 
   manage_mysql_user_lambda_zip = {
     base_path = var.manage_mysql_user_lambda_zip.base_path
-    version = var.manage_mysql_user_lambda_zip.version
+    version   = var.manage_mysql_user_lambda_zip.version
   }
 
   common_tags = local.common_tags

--- a/terraform/deploy/app/modules.tf
+++ b/terraform/deploy/app/modules.tf
@@ -175,7 +175,6 @@ module "emrfs_lambda" {
   internet_proxy_sg_id       = data.terraform_remote_state.aws_analytical_environment_infra.outputs.internet_proxy_sg
 }
 
-<<<<<<< HEAD
 module "rbac_db" {
   source = "../../modules/aurora_db"
 

--- a/terraform/deploy/app/terraform.tf.j2
+++ b/terraform/deploy/app/terraform.tf.j2
@@ -161,11 +161,21 @@ data "terraform_remote_state" "common" {
 
 provider "aws" {
   version = "~> 2.70.0"
-  alias  = "management"
+  alias  = "management-ami"
   region = var.region
 
   assume_role {
     role_arn = "arn:aws:iam::${local.account["management"]}:role/${var.assume_role}"
+  }
+}
+
+provider "aws" {
+  version = "~> 2.70.0"
+  alias  = "management"
+  region = var.region
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.account[local.management_account[local.environment]]}:role/${var.assume_role}"
   }
 }
 

--- a/terraform/deploy/cognito/modules.tf
+++ b/terraform/deploy/cognito/modules.tf
@@ -44,3 +44,4 @@ module "check-user-expiry-lambda" {
   from_email_address       = "DataWorks Access Management <access-management@${data.terraform_remote_state.aws_common_infrastructure.outputs.domain_identity}>"
   template_bucket          = data.terraform_remote_state.management.outputs.ses_mailer_bucket.id
 }
+

--- a/terraform/modules/data_user_roles/data.tf
+++ b/terraform/modules/data_user_roles/data.tf
@@ -1,4 +1,4 @@
-data "external" "test" {
+data "external" "user_roles" {
   program = [
     "python",
     "${path.module}/data_cognito_user_roles.py"

--- a/terraform/modules/data_user_roles/data.tf
+++ b/terraform/modules/data_user_roles/data.tf
@@ -1,0 +1,24 @@
+data "external" "test" {
+  program = [
+    "python",
+    "${path.module}/data_cognito_user_roles.py"
+
+  ]
+  query = {
+    user_pool_id = var.user_pool_id,
+
+    role = format("arn:%s:%s:%s:%s:%s",
+      data.aws_arn.current_session.partition,
+      "iam",
+      data.aws_arn.current_session.region,
+      data.aws_arn.current_session.account,
+      "role/${split("/", data.aws_arn.current_session.resource)[1]}"
+    )
+  }
+}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_arn" "current_session" {
+  arn = data.aws_caller_identity.current.arn
+}

--- a/terraform/modules/data_user_roles/data.tf
+++ b/terraform/modules/data_user_roles/data.tf
@@ -7,7 +7,7 @@ data "external" "user_roles" {
   query = {
     user_pool_id = var.user_pool_id,
     account_id   = data.aws_arn.current_session.account,
-    region       = data.aws_arn.current_session.region,
+    region       = data.aws_region.current.name,
 
     role = format("arn:%s:%s:%s:%s:%s",
       data.aws_arn.current_session.partition,
@@ -24,3 +24,5 @@ data "aws_caller_identity" "current" {}
 data "aws_arn" "current_session" {
   arn = data.aws_caller_identity.current.arn
 }
+
+data "aws_region" "current" {}

--- a/terraform/modules/data_user_roles/data.tf
+++ b/terraform/modules/data_user_roles/data.tf
@@ -6,6 +6,8 @@ data "external" "user_roles" {
   ]
   query = {
     user_pool_id = var.user_pool_id,
+    account_id   = data.aws_arn.current_session.account,
+    region       = data.aws_arn.current_session.region,
 
     role = format("arn:%s:%s:%s:%s:%s",
       data.aws_arn.current_session.partition,
@@ -14,8 +16,6 @@ data "external" "user_roles" {
       data.aws_arn.current_session.account,
       "role/${split("/", data.aws_arn.current_session.resource)[1]}"
     )
-
-    account_id = data.aws_arn.current_session.account
   }
 }
 

--- a/terraform/modules/data_user_roles/data.tf
+++ b/terraform/modules/data_user_roles/data.tf
@@ -14,6 +14,8 @@ data "external" "user_roles" {
       data.aws_arn.current_session.account,
       "role/${split("/", data.aws_arn.current_session.resource)[1]}"
     )
+
+    account_id = data.aws_arn.current_session.account
   }
 }
 

--- a/terraform/modules/data_user_roles/data_cognito_user_roles.py
+++ b/terraform/modules/data_user_roles/data_cognito_user_roles.py
@@ -25,14 +25,14 @@ def get_cognito_users(cognitoidp_client, user_pool_id):
     return res['Users']
 
 
-def get_roles_for_users(usernames):
-    return dict(map(lambda user: (user, "arn:test_role"), usernames))
+def get_roles_for_users(usernames, account_id):
+    return dict(map(lambda user: (user, f'arn:aws:iam::{account_id}:role/emrfs_{user}'), usernames))
 
 
 def main():
     tf_input = json.loads(sys.stdin.read())
 
-    for var in ['role', 'user_pool_id']:
+    for var in ['role', 'user_pool_id', 'account_id']:
         if var not in tf_input:
             sys.stderr.write("Missing required variable {}".format(var))
             sys.exit(1)
@@ -40,7 +40,7 @@ def main():
     session = get_session(tf_input['role'])
 
     users = get_cognito_users(session.client('cognito-idp'), tf_input['user_pool_id'])
-    users_with_roles = get_roles_for_users(map(lambda user_obj: user_obj['Username'], users))
+    users_with_roles = get_roles_for_users(map(lambda user_obj: user_obj['Username'], users), tf_input['account_id'])
 
     result = {
         'users': json.dumps(users_with_roles),

--- a/terraform/modules/data_user_roles/data_cognito_user_roles.py
+++ b/terraform/modules/data_user_roles/data_cognito_user_roles.py
@@ -5,7 +5,7 @@ import math
 from functools import reduce
 
 
-def get_session(role_arn):
+def get_session(role_arn, region):
     creds = boto3.client('sts').assume_role(
         RoleArn=role_arn,
         RoleSessionName="CognitoUserGetIamRoles"
@@ -14,7 +14,9 @@ def get_session(role_arn):
     return boto3.Session(
         aws_access_key_id=creds['AccessKeyId'],
         aws_secret_access_key=creds['SecretAccessKey'],
-        aws_session_token=creds['SessionToken'])
+        aws_session_token=creds['SessionToken'],
+        region_name=region
+    )
 
 
 def get_cognito_users(cognitoidp_client, user_pool_id):
@@ -37,9 +39,9 @@ def main():
             sys.stderr.write("Missing required variable {}".format(var))
             sys.exit(1)
 
-    session = get_session(tf_input['role'])
+    session = get_session(tf_input['role'], tf_input['region'])
 
-    users = get_cognito_users(session.client('cognito-idp', region_name=tf_input['region']), tf_input['user_pool_id'])
+    users = get_cognito_users(session.client('cognito-idp'), tf_input['user_pool_id'])
     users_with_roles = get_roles_for_users(map(lambda user_obj: user_obj['Username'], users), tf_input['account_id'])
 
     result = {

--- a/terraform/modules/data_user_roles/data_cognito_user_roles.py
+++ b/terraform/modules/data_user_roles/data_cognito_user_roles.py
@@ -1,0 +1,55 @@
+import sys
+import boto3
+import json
+import math
+from functools import reduce
+
+
+def get_session(role_arn):
+    creds = boto3.client('sts').assume_role(
+        RoleArn=role_arn,
+        RoleSessionName="CognitoUserGetIamRoles"
+    )['Credentials']
+
+    return boto3.Session(
+        aws_access_key_id=creds['AccessKeyId'],
+        aws_secret_access_key=creds['SecretAccessKey'],
+        aws_session_token=creds['SessionToken'])
+
+
+def get_cognito_users(cognitoidp_client, user_pool_id):
+    res = cognitoidp_client.list_users(
+        UserPoolId=user_pool_id,
+        Filter="cognito:user_status=\"CONFIRMED\""
+    )
+    return res['Users']
+
+
+def get_roles_for_users(usernames):
+    return dict(map(lambda user: (user, "arn:test_role"), usernames))
+
+
+def main():
+    tf_input = json.loads(sys.stdin.read())
+
+    for var in ['role', 'user_pool_id']:
+        if var not in tf_input:
+            sys.stderr.write("Missing required variable {}".format(var))
+            sys.exit(1)
+
+    session = get_session(tf_input['role'])
+
+    users = get_cognito_users(session.client('cognito-idp'), tf_input['user_pool_id'])
+    users_with_roles = get_roles_for_users(map(lambda user_obj: user_obj['Username'], users))
+
+    result = {
+        'users': json.dumps(users_with_roles),
+        'num_security_configs': str(int(math.ceil(
+            sum(map(lambda key: len(key) + len(users_with_roles[key]) + 100, users_with_roles.keys())) / 60000.0)))
+    }
+
+    print(json.dumps(result))
+
+
+if __name__ == '__main__':
+    main()

--- a/terraform/modules/data_user_roles/data_cognito_user_roles.py
+++ b/terraform/modules/data_user_roles/data_cognito_user_roles.py
@@ -15,7 +15,7 @@ def get_session(role_arn, region):
         aws_access_key_id=creds['AccessKeyId'],
         aws_secret_access_key=creds['SecretAccessKey'],
         aws_session_token=creds['SessionToken'],
-        region_name='eu-west-2'
+        region_name=region
     )
 
 

--- a/terraform/modules/data_user_roles/data_cognito_user_roles.py
+++ b/terraform/modules/data_user_roles/data_cognito_user_roles.py
@@ -15,7 +15,7 @@ def get_session(role_arn, region):
         aws_access_key_id=creds['AccessKeyId'],
         aws_secret_access_key=creds['SecretAccessKey'],
         aws_session_token=creds['SessionToken'],
-        region_name=region
+        region_name='eu-west-2'
     )
 
 

--- a/terraform/modules/data_user_roles/data_cognito_user_roles.py
+++ b/terraform/modules/data_user_roles/data_cognito_user_roles.py
@@ -32,14 +32,14 @@ def get_roles_for_users(usernames, account_id):
 def main():
     tf_input = json.loads(sys.stdin.read())
 
-    for var in ['role', 'user_pool_id', 'account_id']:
+    for var in ['role', 'user_pool_id', 'account_id', 'region']:
         if var not in tf_input:
             sys.stderr.write("Missing required variable {}".format(var))
             sys.exit(1)
 
     session = get_session(tf_input['role'])
 
-    users = get_cognito_users(session.client('cognito-idp'), tf_input['user_pool_id'])
+    users = get_cognito_users(session.client('cognito-idp', region_name=tf_input['region']), tf_input['user_pool_id'])
     users_with_roles = get_roles_for_users(map(lambda user_obj: user_obj['Username'], users), tf_input['account_id'])
 
     result = {

--- a/terraform/modules/data_user_roles/output.tf
+++ b/terraform/modules/data_user_roles/output.tf
@@ -1,6 +1,6 @@
 output "output" {
   value = {
-    users = jsondecode(data.external.test.result.users)
-    num_configs_needed = data.external.test.result.num_security_configs
+    users              = jsondecode(data.external.user_roles.result.users)
+    num_configs_needed = data.external.user_roles.result.num_security_configs
   }
 }

--- a/terraform/modules/data_user_roles/output.tf
+++ b/terraform/modules/data_user_roles/output.tf
@@ -1,0 +1,6 @@
+output "output" {
+  value = {
+    users = jsondecode(data.external.test.result.users)
+    num_configs_needed = data.external.test.result.num_security_configs
+  }
+}

--- a/terraform/modules/data_user_roles/variables.tf
+++ b/terraform/modules/data_user_roles/variables.tf
@@ -1,3 +1,3 @@
-variable "user_pool_id"{
+variable "user_pool_id" {
   type = string
 }

--- a/terraform/modules/data_user_roles/variables.tf
+++ b/terraform/modules/data_user_roles/variables.tf
@@ -1,0 +1,3 @@
+variable "user_pool_id"{
+  type = string
+}

--- a/terraform/modules/emr/configuration_security.tf
+++ b/terraform/modules/emr/configuration_security.tf
@@ -20,12 +20,20 @@ locals {
 
     AuthorizationConfiguration = {
       EmrFsConfiguration = {
-        RoleMappings = flatten([
+        RoleMappings = concat([
           for group, policy_suffixes in var.security_configuration_groups : [
             {
               Role           = aws_iam_role.emrfs_iam[group].arn
               IdentifierType = "Group"
               Identifiers    = [group]
+            }
+          ]
+          ], [
+          for user, role in var.security_configuration_user_roles : [
+            {
+              Role           = role
+              IdentifierType = "User"
+              Identifiers    = [user]
             }
           ]
         ])

--- a/terraform/modules/emr/variables.tf
+++ b/terraform/modules/emr/variables.tf
@@ -160,6 +160,12 @@ variable "security_configuration_groups" {
   type        = map(list(string))
 }
 
+variable "security_configuration_user_roles" {
+  description = "Cognito groups to allow access to S3 data"
+  type        = map(string)
+  default     = {}
+}
+
 variable "hive_metastore_username" {
   description = "Username to use when connecting to hive metastore"
   type        = string


### PR DESCRIPTION
* Python install onto Terraform container to allow for external data source script to run 
* Building predictable role ARN from username
* Passing in additional values to POC

- Most of the code is from Dragoș's POC found [here](https://github.com/dwp/aws-analytical-env/compare/dc_DW-5263_poc_user_security_config)