### PR TITLE
DW-5369 Added get-scripts step to  batch_cluster

### DIFF
--- a/analytical_env_cluster_config/steps.yaml.tpl
+++ b/analytical_env_cluster_config/steps.yaml.tpl
@@ -28,3 +28,9 @@ Steps:
     - "s3://${config_bucket}/scripts/emr/livy_client_conf.sh"
     Jar: "s3://eu-west-2.elasticmapreduce/libs/script-runner/script-runner.jar"
   ActionOnFailure: "CONTINUE"
+- Name: "get-scripts"
+  HadoopJarStep:
+    Args:
+    - "s3://${config_bucket}/scripts/emr/get_scripts.sh component/uc_repos /opt/emr"
+    Jar: "s3://eu-west-2.elasticmapreduce/libs/script-runner/script-runner.jar"
+  ActionOnFailure: "CONTINUE"

--- a/batch_cluster_config/steps.yaml.tpl
+++ b/batch_cluster_config/steps.yaml.tpl
@@ -28,3 +28,9 @@ Steps:
     - "s3://${config_bucket}/scripts/emr/livy_client_conf.sh"
     Jar: "s3://eu-west-2.elasticmapreduce/libs/script-runner/script-runner.jar"
   ActionOnFailure: "CONTINUE"
+- Name: "get-scripts"
+  HadoopJarStep:
+    Args:
+    - "s3://${config_bucket}/scripts/emr/get_scripts.sh component/uc_repos /opt/emr"
+    Jar: "s3://eu-west-2.elasticmapreduce/libs/script-runner/script-runner.jar"
+  ActionOnFailure: "CONTINUE"

--- a/terraform/modules/emr/configuration_emr.tf
+++ b/terraform/modules/emr/configuration_emr.tf
@@ -116,7 +116,7 @@ resource "aws_s3_bucket_object" "get_scripts_sh" {
   key    = "scripts/emr/get_scripts.sh"
   content = templatefile("${path.module}/templates/emr/get_scripts.sh",
     {
-      config_bucket = aws_s3_bucket.emr.id
+      config_bucket = var.config_bucket_arn
     }
   )
 


### PR DESCRIPTION
Added get-script step for coping scripts from s3 to the cluster to analytical_env_cluster_config/stepts.yaml/tpl and batch_cluster_config/steps.yaml.tpl and corrected bucket id for get_scripts.sh in configuration_emr.tf