### PR TITLE
DW-5365 Add analytical_env_support RBAC db credentials

### DIFF
--- a/terraform/deploy/app/modules.tf
+++ b/terraform/deploy/app/modules.tf
@@ -198,7 +198,10 @@ module "rbac_db" {
     version   = var.manage_mysql_user_lambda_zip.version
   }
 
-  client_names = ["emrfs-lambda"]
+  client_names = [
+    "emrfs-lambda",
+    "analytical_env_support"
+  ]
 
   common_tags = local.common_tags
 


### PR DESCRIPTION
After this PR has been merged, the `rotate-mysql-client-credentials-*` job in concourse needs to be run for all environments.