### PR TITLE
addressing code smells flagged by sonar cloud

### DIFF
--- a/terraform/modules/emrfs-lambda/cognito-rds-sync-lambda-files/lambda_handler.py
+++ b/terraform/modules/emrfs-lambda/cognito-rds-sync-lambda-files/lambda_handler.py
@@ -24,7 +24,7 @@ def get_env_vars():
 
     for var in variables:
         if var is None or var == {}:
-            raise Exception(f'Variable: {var} has not been provided.')
+            raise AttributeError(f'Variable: {var} has not been provided.')
 
 
 # queries RDS for all user data and returns a dict mapping username to active and user_name_sub

--- a/terraform/modules/emrfs-lambda/cognito-rds-sync-lambda-files/tests/rds_cognito_sync_handler_test.py
+++ b/terraform/modules/emrfs-lambda/cognito-rds-sync-lambda-files/tests/rds_cognito_sync_handler_test.py
@@ -93,7 +93,7 @@ mocked_cognito_user_dict = {'user_one': {'active': True,
 
 # helper function to return true for assertion
 class AnyArg(object):
-    def __eq__(a, b):
+    def __eq__(self, b):
         return True
 
 

--- a/terraform/modules/emrfs-lambda/policy-munge-lambda-files/aws_caller.py
+++ b/terraform/modules/emrfs-lambda/policy-munge-lambda-files/aws_caller.py
@@ -108,11 +108,11 @@ def get_emrfs_roles():
     return return_list
 
 
-def create_role_and_await_consistency(role_name, assumeRoleDoc):
+def create_role_and_await_consistency(role_name, assume_role_doc):
     iam_client.create_role(
         Path="/emrfs/",
         RoleName=role_name,
-        AssumeRolePolicyDocument=assumeRoleDoc
+        AssumeRolePolicyDocument=assume_role_doc
     )
     waiter = iam_client.get_waiter('role_exists')
     waiter.wait(

--- a/terraform/modules/emrfs-lambda/policy-munge-lambda-files/lambda_handler.py
+++ b/terraform/modules/emrfs-lambda/policy-munge-lambda-files/lambda_handler.py
@@ -127,18 +127,17 @@ def get_env_vars():
     for var in variables:
         if var is None or var == {}:
             raise NameError(f'Variable: {var} has not been provided.')
-
     return variables
 
 
 # loops through the desired state (from RDS) and what exists in AWS and creates any missing roles
-def check_roles_exist_and_create_if_not(existing_role_list, user_state_and_policy, assumeRoleDocument):
+def check_roles_exist_and_create_if_not(existing_role_list, user_state_and_policy, assume_role_document):
     roles_after_creation = existing_role_list.copy()
     for user in user_state_and_policy:
         if user_state_and_policy[user]['role_name'] not in existing_role_list \
                 and user_state_and_policy[user]['active']:
             created_role = create_role_and_await_consistency(user_state_and_policy[user]['role_name'],
-                                                             assumeRoleDocument)
+                                                             assume_role_document)
             roles_after_creation.append(created_role)
     return roles_after_creation
 
@@ -188,7 +187,6 @@ def chunk_policies_and_return_dict_of_policy_name_to_json(policy_object_list, us
     # checks to see if 20 policy attachment limit is reached before creating policies
     if (len(dict_of_policy_name_to_munged_policy_objects) > 20):
         raise IndexError(f"Maximum policy assignment exceeded for role: {role_name}")
-
     return dict_of_policy_name_to_munged_policy_objects
 
 


### PR DESCRIPTION
`database_arn` -> `database_cluster_arn` in tests to reflect previous change in handler