### PR TITLE
Dw 5296 munge lambda error handling

### DIFF
--- a/terraform/modules/emrfs-lambda/policy-munge-lambda-files/lambda_handler.py
+++ b/terraform/modules/emrfs-lambda/policy-munge-lambda-files/lambda_handler.py
@@ -88,7 +88,7 @@ def lambda_handler(event, context):
                 )
 
                 attach_policies_to_role(list_of_policy_arns, user_state_and_policy[user_name]['role_name'])
-                delete_tags(user_state_and_policy[user_name]['user_name'])
+                delete_tags(user_state_and_policy[user_name]['role_name'])
                 tag_role_with_policies(
                     user_state_and_policy[user_name]['policy_names'],
                     user_state_and_policy[user_name]['role_name'],
@@ -126,7 +126,7 @@ def get_env_vars():
 
     for var in variables:
         if var is None or var == {}:
-            raise Exception(f'Variable: {var} has not been provided.')
+            raise NameError(f'Variable: {var} has not been provided.')
 
     return variables
 
@@ -166,7 +166,7 @@ def verify_policies(names, list_of_policy_objects):
     policy_object_names = [policy.get('policy_name') for policy in list_of_policy_objects]
     for policy_name in names:
         if policy_name not in policy_object_names:
-            raise Exception(f'Policy missing from Map: {policy_name}')
+            raise NameError(f'Policy missing from Map: {policy_name}')
 
 
 # creates json of policy documents mapped to their policy name using iam_policy_template and statements
@@ -187,7 +187,7 @@ def chunk_policies_and_return_dict_of_policy_name_to_json(policy_object_list, us
 
     # checks to see if 20 policy attachment limit is reached before creating policies
     if (len(dict_of_policy_name_to_munged_policy_objects) > 20):
-        raise Exception(f"Maximum policy assignment exceeded for role: {role_name}")
+        raise IndexError(f"Maximum policy assignment exceeded for role: {role_name}")
 
     return dict_of_policy_name_to_munged_policy_objects
 
@@ -264,7 +264,7 @@ def tag_role_with_policies(policy_list, role_name, common_tags):
             tag_keys_to_value_list[tag_key] = [tag['policy_name']]
 
     if len(tag_keys_to_value_list) > (50-len(common_tags)):
-        raise Exception("Tag limit for role exceeded")
+        raise IndexError("Tag limit for role exceeded")
 
     tag_list = create_tag_list(tag_keys_to_value_list, common_tags)
 
@@ -311,15 +311,15 @@ def get_user_userstatus_policy_dict(variables):
         for record in response['records']:
             user_name = ''.join(record[0].values())
             active = list(record[1].values())[0]
-            policy_name = [''.join(record[2].values())]
+            policy_name = ''.join(record[2].values())
             if return_dict.get(user_name) == None:
                 return_dict[user_name] = {
                     'active': active,
-                    'policy_names': policy_name,
+                    'policy_names': ["emrfs_iam", policy_name],
                     'role_name': f'emrfs_{user_name}'
                 }
             else:
-                return_dict[user_name]['policy_names'].extend(policy_name)
+                return_dict[user_name]['policy_names'].append(policy_name)
     else:
         raise ValueError("No records returned from RDS")
     return return_dict

--- a/terraform/modules/emrfs-lambda/policy-munge-lambda-files/lambda_handler.py
+++ b/terraform/modules/emrfs-lambda/policy-munge-lambda-files/lambda_handler.py
@@ -163,11 +163,10 @@ def create_policy_object_list_from_policy_name_list(names, all_policy_list):
 
 # checks original input against map used for policy
 def verify_policies(names, list_of_policy_objects):
-    policy_object_names = []
-    for policy_object in list_of_policy_objects:
-        policy_object_names.append(policy_object.get('policy_name'))
-    if not names == policy_object_names:
-        raise Exception("Policy missing from Map.")
+    policy_object_names = [policy.get('policy_name') for policy in list_of_policy_objects]
+    for policy_name in names:
+        if policy_name not in policy_object_names:
+            raise Exception(f'Policy missing from Map: {policy_name}')
 
 
 # creates json of policy documents mapped to their policy name using iam_policy_template and statements

--- a/terraform/modules/emrfs-lambda/policy-munge-lambda-files/tests/lambda_handler_tests.py
+++ b/terraform/modules/emrfs-lambda/policy-munge-lambda-files/tests/lambda_handler_tests.py
@@ -21,8 +21,8 @@ mocked_db_response = {
 }
 
 mocked_user_dict = {
-    'user_one': {'active': False, 'policy_names': ['policy_one', 'policy_two'], 'role_name': 'emrfs_user_one'},
-    'user_two': {'active': True, 'policy_names': ['policy_one'], 'role_name': 'emrfs_user_two'}
+    'user_one': {'active': False, 'policy_names': ['emrfs_iam', 'policy_one', 'policy_two'], 'role_name': 'emrfs_user_one'},
+    'user_two': {'active': True, 'policy_names': ['emrfs_iam', 'policy_one'], 'role_name': 'emrfs_user_two'}
 }
 
 mocked_policy_object_list = [
@@ -93,16 +93,17 @@ class LambdaHandlerTests(TestCase):
 
     @patch('lambda_handler.execute_statement')
     def test_get_user_userstatus_policy_dict(self, mock_execute_statement):
-        mock_execute_statement.side_effect = [mocked_db_response, {'numberOfRecordsUpdated': 0,'records': []}]
+        mock_execute_statement.side_effect = [mocked_db_response, {'numberOfRecordsUpdated': 0, 'records': []}]
         result1 = lambda_handler.get_user_userstatus_policy_dict(variables)
 
+        print(result1)
+        print(result1)
         assert result1 == mocked_user_dict
         self.assertRaises(
             ValueError,
             lambda_handler.get_user_userstatus_policy_dict,
             variables
         )
-
 
     @patch('lambda_handler.create_role_and_await_consistency')
     def test_check_roles_exist_and_create_if_not(self, mock_create_role_and_await_consistency):
@@ -212,29 +213,17 @@ class LambdaHandlerTests(TestCase):
     def test_tag_role_with_policies_CHUNKED(self, mock_tag_role):
         lambda_handler.tag_role_with_policies(['policy_one', 'policy_two'], 'emrfs_user_one', variables['common_tags'])
 
-        mock_tag_role.assert_called_with('emrfs_user_one', [
-            {
-                'Key': 'tag1key',
-                'Value': 'tag1val'
-            },
-            {
-                'Key': 'tag2key',
-                'Value': 'tag2val'
-            },
-            {
-                'Key': 'InputPolicies-1of2',
-                'Value': 'policy_one'
-            },
-            {
-                'Key': 'InputPolicies-2of2',
-                'Value': 'policy_two'
-            },
-        ])
-
+        mock_tag_role.assert_called_with(
+            'emrfs_user_one', [
+                {'Key': 'tag1key', 'Value': 'tag1val'},
+                {'Key': 'tag2key', 'Value': 'tag2val'},
+                {'Key': 'InputPolicies-1of2', 'Value': 'policy_one'},
+                {'Key': 'InputPolicies-2of2', 'Value': 'policy_two'},
+            ]
+        )
 
     def test_verify_policies(self):
-        with self.assertRaises(Exception):
-            lambda_handler.verify_policies(['policy_two', 'policy_four'], mocked_policy_object_list)
-        self.assertEqual(None, lambda_handler.verify_policies(['policy_one', 'policy_three'], mocked_policy_object_list))
-        self.assertEqual(None, lambda_handler.verify_policies(['policy_one'], mocked_policy_object_list))
-
+        with self.assertRaises(NameError):
+            lambda_handler.verify_policies(['policy_two'], mocked_policy_object_list)
+        self.assertIsNone(lambda_handler.verify_policies(['policy_one', 'policy_three'], mocked_policy_object_list))
+        self.assertIsNone(lambda_handler.verify_policies(['policy_one'], mocked_policy_object_list))

--- a/terraform/modules/emrfs-lambda/policy-munge-lambda-files/tests/lambda_handler_tests.py
+++ b/terraform/modules/emrfs-lambda/policy-munge-lambda-files/tests/lambda_handler_tests.py
@@ -148,8 +148,8 @@ class LambdaHandlerTests(TestCase):
             'emrfs_user_one'
         )
 
-        assert result.get('user_one-1of2') == {"Version": "2012-10-17", "Statement": [{'test': 'statement1'}]}
-        assert result.get('user_one-2of2') == {"Version": "2012-10-17", "Statement": [{'test': 'statement2'}]}
+        assert result.get('emrfs_user_one-1of2') == {"Version": "2012-10-17", "Statement": [{'test': 'statement1'}]}
+        assert result.get('emrfs_user_one-2of2') == {"Version": "2012-10-17", "Statement": [{'test': 'statement2'}]}
 
     @patch('lambda_handler.char_limit_of_json_policy', 100)
     def test_chunk_policies_and_return_dict_of_policy_name_to_json_NO_CHUNKS(self):
@@ -159,7 +159,7 @@ class LambdaHandlerTests(TestCase):
             'emrfs_user_one'
         )
 
-        assert result.get('user_one-1of1') == {
+        assert result.get('emrfs_user_one-1of1') == {
             "Version": "2012-10-17",
             "Statement": [{'test': 'statement1'}, {'test': 'statement2'}]
         }
@@ -230,4 +230,8 @@ class LambdaHandlerTests(TestCase):
                 'Value': 'policy_two'
             },
         ])
+
+
+    def test_verify_policies(self):
+        self.assertRaises(Exception, lambda_handler.verify_policies(['policy_one'], mocked_policy_object_list))
 

--- a/terraform/modules/emrfs-lambda/policy-munge-lambda-files/tests/lambda_handler_tests.py
+++ b/terraform/modules/emrfs-lambda/policy-munge-lambda-files/tests/lambda_handler_tests.py
@@ -96,8 +96,6 @@ class LambdaHandlerTests(TestCase):
         mock_execute_statement.side_effect = [mocked_db_response, {'numberOfRecordsUpdated': 0, 'records': []}]
         result1 = lambda_handler.get_user_userstatus_policy_dict(variables)
 
-        print(result1)
-        print(result1)
         assert result1 == mocked_user_dict
         self.assertRaises(
             ValueError,
@@ -222,8 +220,12 @@ class LambdaHandlerTests(TestCase):
             ]
         )
 
-    def test_verify_policies(self):
+    def test_verify_policies_raises_error_on_missing_existing_policy(self):
         with self.assertRaises(NameError):
             lambda_handler.verify_policies(['policy_two'], mocked_policy_object_list)
+
+    def test_verify_policies_does_not_raise_error_when_all_policies_found(self):
         self.assertIsNone(lambda_handler.verify_policies(['policy_one', 'policy_three'], mocked_policy_object_list))
+
+    def test_verify_policies_does_not_raise_error_when_additional_policy_found_in_rds(self):
         self.assertIsNone(lambda_handler.verify_policies(['policy_one'], mocked_policy_object_list))

--- a/terraform/modules/emrfs-lambda/policy-munge-lambda-files/tests/lambda_handler_tests.py
+++ b/terraform/modules/emrfs-lambda/policy-munge-lambda-files/tests/lambda_handler_tests.py
@@ -233,5 +233,8 @@ class LambdaHandlerTests(TestCase):
 
 
     def test_verify_policies(self):
-        self.assertRaises(Exception, lambda_handler.verify_policies(['policy_one'], mocked_policy_object_list))
+        with self.assertRaises(Exception):
+            lambda_handler.verify_policies(['policy_two', 'policy_four'], mocked_policy_object_list)
+        self.assertEqual(None, lambda_handler.verify_policies(['policy_one', 'policy_three'], mocked_policy_object_list))
+        self.assertEqual(None, lambda_handler.verify_policies(['policy_one'], mocked_policy_object_list))
 


### PR DESCRIPTION
* Correction of missed `user_name` -> `role_name`
* Raise proper exceptions
* Refactor of verification to use input as source of truth
* Adding in `emrfs_iam` that was missing from all user roles
* Updating tests to allow for new `emrfs_` prefix on policy names
* Additional test for verification logic that was failing

**Tested:**
* Required permissions applied to user roles by munge lambda
* Users synced from Cognito -> RDS (User Table)
* Permissions Persisted
* NOTE: no permissions to view some PDM tables but I am unsure if this is related to changes