### PR TITLE
Dw 5403 personal and team bucket location permissions

### DIFF
--- a/terraform/deploy/app/modules.tf
+++ b/terraform/deploy/app/modules.tf
@@ -182,6 +182,7 @@ module "emrfs_lambda" {
   mgmt_account               = local.account[local.management_account[local.environment]]
   management_role_arn        = "arn:aws:iam::${local.account[local.management_account[local.environment]]}:role/${var.assume_role}"
   environment                = local.environment
+  s3fs_bucket_id             = data.terraform_remote_state.orchestration-service.outputs.s3fs_bucket_id
 }
 
 module "rbac_db" {

--- a/terraform/deploy/app/terraform.tf.j2
+++ b/terraform/deploy/app/terraform.tf.j2
@@ -33,6 +33,20 @@ data "terraform_remote_state" "aws_analytical_environment_infra" {
   }
 }
 
+data "terraform_remote_state" "orchestration-service" {
+  backend = "s3"
+  workspace = terraform.workspace
+
+  config = {
+    bucket         = "{{state_file_bucket}}"
+    key            = "terraform/dataworks/orchestration-service.tfstate"
+    region         = "{{state_file_region}}"
+    encrypt        = true
+    kms_key_id     = "arn:aws:kms:{{state_file_region}}:{{state_file_account}}:key/{{state_file_kms_key}}"
+    dynamodb_table = "remote_state_locks"
+  }
+}
+
 data "terraform_remote_state" "cognito" {
   backend   = "s3"
   workspace = local.management_workspace[local.management_account[local.environment]]

--- a/terraform/modules/emrfs-lambda/policy-munge-lambda-files/lambda_handler.py
+++ b/terraform/modules/emrfs-lambda/policy-munge-lambda-files/lambda_handler.py
@@ -76,8 +76,8 @@ def lambda_handler(event, context):
                     all_policy_list
                 )
 
-                statement = create_policy_document_from_template(user_name, user_state_and_policy[user_name].get('group_names'))
-                s3fs_access_policy_object = create_policy_object_list_from_policy_name_list(statement)
+                statement = create_policy_document_from_template(user_name, user_state_and_policy[user_name].get('group_names'), variables)
+                s3fs_access_policy_object = create_policy_object(statement)
 
                 list_of_policy_objects.append(s3fs_access_policy_object)
 
@@ -124,6 +124,8 @@ def get_env_vars():
     variables['common_tags'] ={}
     variables['assume_role_policy_json'] = os.getenv('ASSUME_ROLE_POLICY_JSON')
     variables['s3fs_bucket_arn'] = os.getenv('FILE_SYSTEM_BUCKET_ARN')
+    variables['region'] = os.getenv('REGION')
+    variables['account'] = os.getenv('ACCOUNT')
 
     common_tags = common_tags_string.split(tag_separator)
     for tag in common_tags:
@@ -327,10 +329,8 @@ def get_user_userstatus_policy_dict(variables):
                     'role_name': f'emrfs_{user_name}'
                 }
             else:
-                # todo: test this logic with 2x same policy
                 if policy_name not in return_dict[user_name]['policy_names']:
                     return_dict[user_name]['policy_names'].append(policy_name)
-                # todo: test group_names are returned and parsed properly
                 if group_name not in return_dict[user_name]['group_names']:
                     return_dict[user_name]['group_names'].append(group_name)
     else:
@@ -338,8 +338,7 @@ def get_user_userstatus_policy_dict(variables):
     return return_dict
 
 
-    # todo: test policy creation logic
-def create_policy_document_from_template(user_name, group_names):
+def create_policy_document_from_template(user_name, group_names, variables):
     with open('s3fs_policy_template.json', 'r') as statement_raw:
         statement = json.load(statement_raw)
 

--- a/terraform/modules/emrfs-lambda/policy-munge-lambda-files/s3fs_policy_template.json
+++ b/terraform/modules/emrfs-lambda/policy-munge-lambda-files/s3fs_policy_template.json
@@ -1,6 +1,6 @@
 [
   {
-    "Sid": "jupyters3accessdocument",
+    "Sid": "s3fsaccessdocument",
     "Effect": "Allow",
     "Action": [
       "s3:PutObject",
@@ -12,7 +12,7 @@
     "Resource": []
   },
   {
-    "Sid": "jupyterkmsaccessdocument",
+    "Sid": "s3fskmsaccessdocument",
     "Effect": "Allow",
     "Action": [
       "kms:Decrypt",
@@ -24,7 +24,7 @@
     "Resource": []
   },
   {
-    "Sid": "jupyters3list",
+    "Sid": "s3fslist",
     "Effect": "Allow",
     "Action": [
       "s3:ListBucket"

--- a/terraform/modules/emrfs-lambda/policy-munge-lambda-files/s3fs_policy_template.json
+++ b/terraform/modules/emrfs-lambda/policy-munge-lambda-files/s3fs_policy_template.json
@@ -1,0 +1,34 @@
+[
+  {
+    "Sid": "jupyters3accessdocument",
+    "Effect": "Allow",
+    "Action": [
+      "s3:PutObject",
+      "s3:GetObject",
+      "s3:PutObjectAcl",
+      "s3:GetObjectVersion",
+      "s3:DeleteObject"
+    ],
+    "Resource": []
+  },
+  {
+    "Sid": "jupyterkmsaccessdocument",
+    "Effect": "Allow",
+    "Action": [
+      "kms:Decrypt",
+      "kms:Encrypt",
+      "kms:DescribeKey",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*"
+    ],
+    "Resource": []
+  },
+  {
+    "Sid": "jupyters3list",
+    "Effect": "Allow",
+    "Action": [
+      "s3:ListBucket"
+    ],
+    "Resource": []
+  }
+]

--- a/terraform/modules/emrfs-lambda/policy_munge_lambda.tf
+++ b/terraform/modules/emrfs-lambda/policy_munge_lambda.tf
@@ -15,6 +15,7 @@ resource "aws_lambda_function" "policy_munge_lambda" {
       SECRET_ARN              = var.db_client_secret_arn
       COMMON_TAGS             = join(",", [for key, val in var.common_tags : "${key}:${val}"])
       ASSUME_ROLE_POLICY_JSON = "${var.emrfs_iam_assume_role_json}"
+      FILE_SYSTEM_BUCKET_ARN  = "arn:aws:s3:::${var.s3fs_bucket_id}"
     }
   }
 

--- a/terraform/modules/emrfs-lambda/policy_munge_lambda.tf
+++ b/terraform/modules/emrfs-lambda/policy_munge_lambda.tf
@@ -16,6 +16,8 @@ resource "aws_lambda_function" "policy_munge_lambda" {
       COMMON_TAGS             = join(",", [for key, val in var.common_tags : "${key}:${val}"])
       ASSUME_ROLE_POLICY_JSON = "${var.emrfs_iam_assume_role_json}"
       FILE_SYSTEM_BUCKET_ARN  = "arn:aws:s3:::${var.s3fs_bucket_id}"
+      REGION                  = var.region
+      ACCOUNT                 = var.account
     }
   }
 

--- a/terraform/modules/emrfs-lambda/variables.tf
+++ b/terraform/modules/emrfs-lambda/variables.tf
@@ -72,3 +72,8 @@ variable "environment" {
   type        = string
   description = "(Required) The local environment that Terraform is running in"
 }
+
+variable "s3fs_bucket_id" {
+  type        = string
+  description = "(Required) The bucket ID for s3fs shared and home dir bucket"
+}


### PR DESCRIPTION
* Extending the policy munge lambda to query groups and assign permissions based on group permissions.
* Mapping the current Orchestration Service User Role creation onto RBAC 2.0 with Aurora RDS over Cognito
* Testing new logic