### PR TITLE
Multiple subnets

### DIFF
--- a/analytical_env_cluster_config/configurations.yaml.tpl
+++ b/analytical_env_cluster_config/configurations.yaml.tpl
@@ -61,7 +61,4 @@ Configurations:
     "hive.mapred.mode": "nonstrict"
 - Classification: "emrfs-site"
   Properties:
-    "fs.s3.consistent": "true"
-    "fs.s3.consistent.metadata.tableName": "EmrFSMetadata"
-    "fs.s3.consistent.retryCount": "5"
-    "fs.s3.consistent.retryPeriodSeconds": "3"
+    "fs.s3.maxRetries": "20"

--- a/analytical_env_cluster_config/instances.yaml.tpl
+++ b/analytical_env_cluster_config/instances.yaml.tpl
@@ -5,29 +5,44 @@ Instances:
   - "${common_security_group}"
   AdditionalSlaveSecurityGroups:
   - "${common_security_group}"
-  Ec2SubnetIds: 
-  - "${subnet_id}"
+  Ec2SubnetIds: ${jsonencode(split(",", subnet_ids))}
   EmrManagedMasterSecurityGroup: "${master_security_group}"
   EmrManagedSlaveSecurityGroup: "${slave_security_group}"
   ServiceAccessSecurityGroup: "${service_security_group}"
-  InstanceGroups:
-  - Name: CORE
-    InstanceCount: 1
-    InstanceType: "m5.2xlarge"
-    InstanceRole: "CORE"
-    EbsConfiguration:
-      EbsBlockDeviceConfigs:
+  InstanceFleets:
+  - InstanceFleetType: "MASTER"
+    Name: MASTER
+    TargetOnDemandCapacity: 1
+    InstanceTypeConfigs:
+    - EbsConfiguration:
+        EbsBlockDeviceConfigs:
         - VolumeSpecification:
             SizeInGB: 250
             VolumeType: "gp2"
           VolumesPerInstance: 1
-  - Name: MASTER
-    InstanceCount: 1
-    InstanceType: "m5.2xlarge"
-    InstanceRole: "MASTER"
-    EbsConfiguration:
-      EbsBlockDeviceConfigs:
+      InstanceType: "m5.2xlarge"
+  - InstanceFleetType: "CORE"
+    Name: CORE
+    TargetOnDemandCapacity: 1
+    InstanceTypeConfigs:
+    - EbsConfiguration:
+        EbsBlockDeviceConfigs:
         - VolumeSpecification:
             SizeInGB: 250
             VolumeType: "gp2"
           VolumesPerInstance: 1
+      InstanceType: "m5.2xlarge"
+    - EbsConfiguration:
+        EbsBlockDeviceConfigs:
+        - VolumeSpecification:
+            SizeInGB: 250
+            VolumeType: "gp2"
+          VolumesPerInstance: 1
+      InstanceType: "m5a.2xlarge"
+    - EbsConfiguration:
+        EbsBlockDeviceConfigs:
+        - VolumeSpecification:
+            SizeInGB: 250
+            VolumeType: "gp2"
+          VolumesPerInstance: 1
+      InstanceType: "m5d.2xlarge"

--- a/batch_cluster_config/configurations.yaml.tpl
+++ b/batch_cluster_config/configurations.yaml.tpl
@@ -61,7 +61,4 @@ Configurations:
     "hive.mapred.mode": "nonstrict"
 - Classification: "emrfs-site"
   Properties:
-    "fs.s3.consistent": "true"
-    "fs.s3.consistent.metadata.tableName": "EmrFSMetadata"
-    "fs.s3.consistent.retryCount": "5"
-    "fs.s3.consistent.retryPeriodSeconds": "3"
+    "fs.s3.maxRetries": "20"

--- a/batch_cluster_config/instances.yaml.tpl
+++ b/batch_cluster_config/instances.yaml.tpl
@@ -5,29 +5,44 @@ Instances:
   - "${common_security_group}"
   AdditionalSlaveSecurityGroups:
   - "${common_security_group}"
-  Ec2SubnetIds:
-  - "${subnet_id}"
+  Ec2SubnetIds: ${jsonencode(split(",", subnet_ids))}
   EmrManagedMasterSecurityGroup: "${master_security_group}"
   EmrManagedSlaveSecurityGroup: "${slave_security_group}"
   ServiceAccessSecurityGroup: "${service_security_group}"
-  InstanceGroups:
-  - Name: CORE
-    InstanceCount: ${core_instance_count}
-    InstanceType: "m5.2xlarge"
-    InstanceRole: "CORE"
-    EbsConfiguration:
-      EbsBlockDeviceConfigs:
+  InstanceFleets:
+  - InstanceFleetType: "MASTER"
+    Name: MASTER
+    TargetOnDemandCapacity: 1
+    InstanceTypeConfigs:
+    - EbsConfiguration:
+        EbsBlockDeviceConfigs:
         - VolumeSpecification:
             SizeInGB: 250
             VolumeType: "gp2"
           VolumesPerInstance: 1
-  - Name: MASTER
-    InstanceCount: 1
-    InstanceType: "m5.2xlarge"
-    InstanceRole: "MASTER"
-    EbsConfiguration:
-      EbsBlockDeviceConfigs:
+      InstanceType: "m5.2xlarge"
+  - InstanceFleetType: "CORE"
+    Name: CORE
+    TargetOnDemandCapacity: ${core_instance_count}
+    InstanceTypeConfigs:
+    - EbsConfiguration:
+        EbsBlockDeviceConfigs:
         - VolumeSpecification:
             SizeInGB: 250
             VolumeType: "gp2"
           VolumesPerInstance: 1
+      InstanceType: "m5.2xlarge"
+    - EbsConfiguration:
+        EbsBlockDeviceConfigs:
+        - VolumeSpecification:
+            SizeInGB: 250
+            VolumeType: "gp2"
+          VolumesPerInstance: 1
+      InstanceType: "m5a.2xlarge"
+    - EbsConfiguration:
+        EbsBlockDeviceConfigs:
+        - VolumeSpecification:
+            SizeInGB: 250
+            VolumeType: "gp2"
+          VolumesPerInstance: 1
+      InstanceType: "m5d.2xlarge"

--- a/terraform/deploy/app/modules.tf
+++ b/terraform/deploy/app/modules.tf
@@ -166,7 +166,7 @@ module launcher {
   hive_metastore_username               = jsondecode(data.aws_secretsmanager_secret_version.hive_metastore_password_secret.secret_string)["username"]
   batch_security_configuration          = module.emr.batch_security_configuration
   hive_metastore_arn                    = data.aws_secretsmanager_secret_version.hive_metastore_password_secret.arn
-  subnet_id                             = data.terraform_remote_state.aws_analytical_environment_infra.outputs.vpc.aws_subnets_private[0].id
+  subnet_ids                            = data.terraform_remote_state.aws_analytical_environment_infra.outputs.vpc.aws_subnets_private.*.id
   core_instance_count                   = var.emr_core_instance_count[local.environment]
   environment                           = local.environment
 }

--- a/terraform/modules/emr-launcher/s3.tf
+++ b/terraform/modules/emr-launcher/s3.tf
@@ -22,7 +22,7 @@ resource "aws_s3_bucket_object" "analytical_env_instances" {
     master_security_group  = var.master_security_group
     slave_security_group   = var.slave_security_group
     service_security_group = var.service_security_group
-    subnet_id              = join(",", var.subnet_ids)
+    subnet_ids             = join(",", var.subnet_ids)
   })
   tags = merge(var.common_tags, { Name : "${var.name_prefix}-emr-launch-instances" })
 }
@@ -75,7 +75,7 @@ resource "aws_s3_bucket_object" "batch_instances" {
     master_security_group  = var.master_security_group
     slave_security_group   = var.slave_security_group
     service_security_group = var.service_security_group
-    subnet_id              = join(",", var.subnet_ids)
+    subnet_ids             = join(",", var.subnet_ids)
     core_instance_count    = var.core_instance_count
   })
   tags = merge(var.common_tags, { Name : "${var.name_prefix}-emr-launch-instances" })

--- a/terraform/modules/emr-launcher/s3.tf
+++ b/terraform/modules/emr-launcher/s3.tf
@@ -22,7 +22,7 @@ resource "aws_s3_bucket_object" "analytical_env_instances" {
     master_security_group  = var.master_security_group
     slave_security_group   = var.slave_security_group
     service_security_group = var.service_security_group
-    subnet_id              = var.subnet_id
+    subnet_id              = join(",", var.subnet_ids)
   })
   tags = merge(var.common_tags, { Name : "${var.name_prefix}-emr-launch-instances" })
 }
@@ -75,7 +75,7 @@ resource "aws_s3_bucket_object" "batch_instances" {
     master_security_group  = var.master_security_group
     slave_security_group   = var.slave_security_group
     service_security_group = var.service_security_group
-    subnet_id              = var.subnet_id
+    subnet_id              = join(",", var.subnet_ids)
     core_instance_count    = var.core_instance_count
   })
   tags = merge(var.common_tags, { Name : "${var.name_prefix}-emr-launch-instances" })

--- a/terraform/modules/emr-launcher/variables.tf
+++ b/terraform/modules/emr-launcher/variables.tf
@@ -42,7 +42,8 @@ variable "hive_metastore_arn" {
 }
 variable "subnet_ids" {
   type        = map(string)
-  description = "(Required) The ids of the subnets for the cluster"}
+  description = "(Required) The ids of the subnets for the cluster"
+}
 
 variable "core_instance_count" {
   type        = string

--- a/terraform/modules/emr-launcher/variables.tf
+++ b/terraform/modules/emr-launcher/variables.tf
@@ -40,7 +40,9 @@ variable "hive_metastore_arn" {
   description = "the Hive metastore  arn "
   type        = string
 }
-variable "subnet_id" {}
+variable "subnet_ids" {
+  type        = map(string)
+  description = "(Required) The ids of the subnets for the cluster"}
 
 variable "core_instance_count" {
   type        = string

--- a/terraform/modules/emr-launcher/variables.tf
+++ b/terraform/modules/emr-launcher/variables.tf
@@ -41,7 +41,7 @@ variable "hive_metastore_arn" {
   type        = string
 }
 variable "subnet_ids" {
-  type        = map(string)
+  type        = list(string)
   description = "(Required) The ids of the subnets for the cluster"
 }
 

--- a/terraform/modules/emr/templates/emr/configuration.glue.json
+++ b/terraform/modules/emr/templates/emr/configuration.glue.json
@@ -52,10 +52,7 @@
   {
     "Classification": "emrfs-site",
     "Properties": {
-      "fs.s3.consistent.retryPeriodSeconds": "3",
-      "fs.s3.consistent.retryCount": "5",
-      "fs.s3.consistent": "true",
-      "fs.s3.consistent.metadata.tableName": "EmrFSMetadata"
+      "fs.s3.maxRetries": "20"
     }
   }
 ]

--- a/terraform/modules/emr/templates/emr/configuration.mysql.json
+++ b/terraform/modules/emr/templates/emr/configuration.mysql.json
@@ -74,10 +74,7 @@
   {
     "Classification": "emrfs-site",
     "Properties": {
-      "fs.s3.consistent.retryPeriodSeconds": "3",
-      "fs.s3.consistent.retryCount": "5",
-      "fs.s3.consistent": "true",
-      "fs.s3.consistent.metadata.tableName": "EmrFSMetadata"
+      "fs.s3.maxRetries": "20"
     }
   },
   {

--- a/terraform/modules/testing/create_metrics_data_batch_job.tf
+++ b/terraform/modules/testing/create_metrics_data_batch_job.tf
@@ -58,4 +58,11 @@ resource "aws_batch_job_definition" "create_metrics_data_batch_job" {
         ]
     }
   CONTAINER_PROPERTIES
+
+  tags = merge(
+    var.common_tags,
+    {
+      Name = "${var.name_prefix}-create-metrics-data-batch-job",
+    }
+  )
 }

--- a/terraform/modules/testing/create_metrics_data_batch_job.tf
+++ b/terraform/modules/testing/create_metrics_data_batch_job.tf
@@ -58,11 +58,4 @@ resource "aws_batch_job_definition" "create_metrics_data_batch_job" {
         ]
     }
   CONTAINER_PROPERTIES
-
-  tags = merge(
-    var.common_tags,
-    {
-      Name = "${var.name_prefix}-create-metrics-data-batch-job",
-    }
-  )
 }


### PR DESCRIPTION
Switch the launched clusters to using EMR subnets and remove consistent view which is no longer used or recommended on EMR