### PR TITLE
Dw 5673 duplicate user issue in sync lambda

### DIFF
--- a/terraform/modules/emrfs-lambda/cognito-rds-sync-lambda-files/lambda_handler.py
+++ b/terraform/modules/emrfs-lambda/cognito-rds-sync-lambda-files/lambda_handler.py
@@ -30,7 +30,7 @@ def get_env_vars():
 # queries RDS for all user data and returns a dict mapping username+sub to username, active and account_name
 def get_user_dict_from_rds(variables_dict):
     return_dict = {}
-    sql = f'SELECT User.userName, User.active FROM User'
+    sql = f'SELECT User.accountName, User.userName, User.active FROM User'
 
     response = execute_statement(
         sql,
@@ -83,7 +83,9 @@ def sync_values(cognito_user_dict, rds_user_dict, variables_dict):
     users_from_cognito = list(cognito_user_dict.keys())
     users_from_rds = list(rds_user_dict.keys())
     missing_from_rds = [key for key in users_from_cognito if key not in users_from_rds]
+    print(missing_from_rds)
     removed_from_cognito = [key for key in users_from_rds if key not in users_from_cognito]
+    print(removed_from_cognito)
 
     for user in removed_from_cognito:
         update_user_status(user, variables_dict, 0)
@@ -100,6 +102,7 @@ def sync_values(cognito_user_dict, rds_user_dict, variables_dict):
 def add_user_to_rds(user_name_sub, account_name, variables_dict, status):
     sql = f'INSERT INTO User (userName, active, accountName) ' \
           f'VALUES ("{user_name_sub}", {status}, "{account_name}");'
+    print(sql)
     execute_statement(
         sql,
         variables_dict['secret_arn'],
@@ -110,6 +113,7 @@ def add_user_to_rds(user_name_sub, account_name, variables_dict, status):
 
 def update_user_status(user_name, variables_dict, new_status):
     sql = f'UPDATE User SET active = {new_status} WHERE userName = "{user_name}";'
+    print(sql)
     execute_statement(
         sql,
         variables_dict['secret_arn'],

--- a/terraform/modules/emrfs-lambda/cognito-rds-sync-lambda-files/tests/rds_cognito_sync_handler_test.py
+++ b/terraform/modules/emrfs-lambda/cognito-rds-sync-lambda-files/tests/rds_cognito_sync_handler_test.py
@@ -12,25 +12,28 @@ variables['mgmt_account_role_arn'] = 'arn:12345432::mgmt_role_arn'
 mocked_db_response = {
     'numberOfRecordsUpdated': 0,
     'records': [
-        [{'stringValue': 'user_one123'}, {'booleanValue': False}],
-        [{'stringValue': 'user_two654'}, {'booleanValue': True}],
-        [{'stringValue': 'user_one123'}, {'booleanValue': False}],
-        [{'stringValue': 'user_four987'}, {'booleanValue': True}],
+        [{'stringValue': 'user_one'}, {'stringValue': 'user_one123'}, {'booleanValue': False}],
+        [{'stringValue': 'user_two'}, {'stringValue': 'user_two654'}, {'booleanValue': True}],
+        [{'stringValue': 'user_one'}, {'stringValue': 'user_one123'}, {'booleanValue': False}],
+        [{'stringValue': 'user_four'}, {'stringValue': 'user_four987'}, {'booleanValue': True}],
     ]
 }
 
 mocked_rds_user_dict = {
-    'user_one': {
+    'user_one123': {
         'active': False,
-        'user_name_sub': 'user_one123'
+        'username': 'user_one',
+        'account_name': 'user_one'
     },
-    'user_two': {
+    'user_two654': {
         'active': True,
-        'user_name_sub': 'user_two654'
+        'username': 'user_two',
+        'account_name': 'user_two'
     },
-    'user_four': {
+    'user_four987': {
         'active': True,
-        'user_name_sub': 'user_four987'
+        'username': 'user_four',
+        'account_name': 'user_four'
     }
 }
 
@@ -76,20 +79,96 @@ mocked_cognito_list_users_response = [{
     "UserStatus": "SAMPLE_STATUS"
 }]
 
-mocked_cognito_user_dict = {'user_one': {'active': True,
-                                         'user_name_sub': 'user_one123',
+mocked_cognito_user_dict = {'user_one123': {'active': True,
+                                         'username': 'user_one',
                                          'account_name': 'user_one'
                                          },
-                            'user_two': {'active': False,
-                                         'user_name_sub': 'user_two654',
+                            'user_two654': {'active': False,
+                                         'username': 'user_two',
                                          'account_name': 'user_two'
                                          },
-                            'user_three': {'active': True,
-                                           'user_name_sub': 'user_three876',
+                            'user_three876': {'active': True,
+                                           'username': 'user_three',
                                            'account_name': 'account_name_only'
                                            }
                             }
 
+mocked_cognito_response_duplicate_user = [
+    {
+        "Username": "user.one@email.com",
+        "Attributes": [
+            {
+                "Name": "sub",
+                "Value": "876543234567876543234"
+            },
+            {
+                "Name": "preferred_username",
+                "Value": "12345"
+            }
+        ],
+        "UserCreateDate": 12345,
+        "UserLastModifiedDate": 23456,
+        "Enabled": True,
+        "UserStatus": "SAMPLE_STATUS"
+    },
+    {
+        "Username": "user.two@email.com",
+        "Attributes": [
+            {
+                "Name": "sub",
+                "Value": "2846923846928360823"
+            },
+            {
+                "Name": "preferred_username",
+                "Value": "678910"
+            }
+        ],
+        "UserCreateDate": 12345,
+        "UserLastModifiedDate": 23456,
+        "Enabled": True,
+        "UserStatus": "SAMPLE_STATUS"
+    },
+    {
+        "Username": "user.one.new@email.com",
+        "Attributes": [
+            {
+                "Name": "sub",
+                "Value": "9835823840237409470"
+            },
+            {
+                "Name": "preferred_username",
+                "Value": "12345"
+            }
+        ],
+        "UserCreateDate": 12345,
+        "UserLastModifiedDate": 23456,
+        "Enabled": True,
+        "UserStatus": "SAMPLE_STATUS"
+    },
+    {
+        "Username": "user_no_adfs",
+        "Attributes": [
+            {
+                "Name": "sub",
+                "Value": "654345676543234567765"
+            }
+        ],
+        "UserCreateDate": 12345,
+        "UserLastModifiedDate": 23456,
+        "Enabled": False,
+        "UserStatus": "SAMPLE_STATUS"
+    }
+]
+
+mocked_db_response_duplicate_user = {
+    'numberOfRecordsUpdated': 0,
+    'records': [
+        # COLUMNS:       accountName                            userName                       active
+        [{'stringValue': 'user.two@email.com'}, {'stringValue': '678910284'}, {'booleanValue': True}],
+        [{'stringValue': 'user.one@email.com'}, {'stringValue': '12345876'}, {'booleanValue': True}],
+        [{'stringValue': 'user_no_adfs'}, {'stringValue': 'user_no_adfs654'}, {'booleanValue': False}]
+    ]
+}
 
 # helper function to return true for assertion
 class AnyArg(object):
@@ -124,34 +203,60 @@ class LambdaHandlerTests(TestCase):
         mock_get_users_in_userpool.return_value = mocked_cognito_list_users_response
         result = lambda_handler.get_user_dict_from_cognito(variables['cognito_userpool_id'])
 
-        assert result['user_three']['account_name'] == 'account_name_only'
+        assert result['user_three876']['account_name'] == 'account_name_only'
         assert result == mocked_cognito_user_dict
 
     @patch('lambda_handler.execute_statement')
     def test_sync_values(self, mock_execute_statement):
         calls = [
             call(
-                'UPDATE User SET active = 0 WHERE username = "user_four987";',
-                variables['secret_arn'],
-                variables["database_name"],
-                variables["database_cluster_arn"]),
+                'UPDATE User SET active = 0 WHERE userName = "user_four987";',
+                'arn:12345432::secret_test_arn',
+                'test_db',
+                'arn:12345432::test_arn'
+            ),
             call(
-                'INSERT INTO User (username, active, accountname) VALUES ("user_three876", 1, "account_name_only");',
-                variables['secret_arn'],
-                variables["database_name"],
-                variables["database_cluster_arn"]),
+                'INSERT INTO User (userName, active, accountName) VALUES ("user_three876", 1, "account_name_only");',
+                 'arn:12345432::secret_test_arn',
+                'test_db',
+                'arn:12345432::test_arn'
+                 ),
             call(
-                'UPDATE User SET active = 0 WHERE username = "user_two654";',
-                variables['secret_arn'],
-                variables["database_name"],
-                variables["database_cluster_arn"]),
+                'UPDATE User SET active = 0 WHERE userName = "user_two654";',
+                'arn:12345432::secret_test_arn',
+                'test_db',
+                'arn:12345432::test_arn'
+            ),
             call(
-                'UPDATE User SET active = 1 WHERE username = "user_one123";',
-                variables['secret_arn'],
-                variables["database_name"],
-                variables["database_cluster_arn"])
+                'UPDATE User SET active = 1 WHERE userName = "user_one123";',
+                'arn:12345432::secret_test_arn',
+                'test_db',
+                'arn:12345432::test_arn'
+            )
         ]
         lambda_handler.sync_values(mocked_cognito_user_dict, mocked_rds_user_dict, variables)
 
         mock_execute_statement.assert_has_calls(calls, any_order=True)
         assert 4 == mock_execute_statement.call_count
+
+
+    @patch('lambda_handler.create_cognito_client')
+    @patch('lambda_handler.os.getenv')
+    @patch('lambda_handler.get_users_in_userpool')
+    @patch('lambda_handler.execute_statement')
+    def test_duplication_of_adfs_user_due_to_email_change(self, mock_execute_statement, mock_get_users_in_userpool, mock_get_env, mock_create_cognito_client):
+        mock_execute_statement.side_effect = [mocked_db_response_duplicate_user, None]
+        mock_get_users_in_userpool.return_value = mocked_cognito_response_duplicate_user
+        mock_get_env.side_effect = [variables['database_cluster_arn'],
+                                    variables['database_name'],
+                                    variables['secret_arn'],
+                                    variables['cognito_userpool_id'],
+                                    variables['mgmt_account_role_arn']]
+
+        lambda_handler.lambda_handler("", "")
+
+        mock_execute_statement.assert_called_with('INSERT INTO User (userName, active, accountName) VALUES ("12345983", 1, "user.one.new@email.com");',
+                                               'arn:12345432::secret_test_arn',
+                                               'test_db',
+                                               'arn:12345432::test_arn'
+                                               )


### PR DESCRIPTION
* Updating code to index user dicts from Cognito and RDS by `<username><sub>` over `<username>` to avoid duplication issue mentioned in ticket
* Updating tests to follow new pattern
* Writing test to run lambda e2e and verify change