### PR TITLE
use the new generic name

### DIFF
--- a/terraform/modules/emr/templates/emr/trigger_s3_tagger_batch_job.sh
+++ b/terraform/modules/emr/templates/emr/trigger_s3_tagger_batch_job.sh
@@ -16,7 +16,7 @@ export https_proxy
 echo "Triggering tagger with JobName $JOB_NAME and s3 prefix $S3_PREFIX"
 aws batch submit-job \
 --job-queue pdm_object_tagger \
---job-definition pdm_object_tagger_job \
+--job-definition s3_object_tagger_job \
 --job-name "$JOB_NAME" \
 --parameters \
 "{\"data-s3-prefix\": \"$S3_PREFIX\", \"csv-location\": \"s3://${config_bucket}/component/rbac/data_classification.csv\"}"


### PR DESCRIPTION
point to new job definition labelled s3_object_tagger. the job queue remains the same