### PR TITLE
Fix EC2 role permissions

### DIFF
--- a/terraform/modules/emr/iam.tf
+++ b/terraform/modules/emr/iam.tf
@@ -578,7 +578,7 @@ data "aws_iam_policy_document" "analytical_env_metadata_change" {
     ]
 
     resources = [
-      "arn:aws:ec2:${var.region}:${var.account}:instance/*",
+      "*",
     ]
   }
 }


### PR DESCRIPTION
Fixes IAM permissions so the EC2 role can manipulate tags during bootstraping