### PR TITLE
DW-6589: Add autoscaling endpoint to analytical-env VPC

### DIFF
--- a/terraform/deploy/infra/modules.tf
+++ b/terraform/deploy/infra/modules.tf
@@ -30,7 +30,8 @@ module analytical_env_vpc {
     "git-codecommit",
     "sts",
     "secretsmanager",
-    "sns"
+    "sns",
+    "autoscaling"
   ]
 
   custom_vpce_services = [


### PR DESCRIPTION
Add autoscaling endpoint to analytical-env VPC to allow health check to mark EC2 instance as unhealthy when ECS agent is dysfunctional