### PR TITLE
DW-6632 Fix EMR redeploy on every terraform apply

### DIFF
--- a/terraform/modules/emr/emr.tf
+++ b/terraform/modules/emr/emr.tf
@@ -57,6 +57,13 @@ resource "aws_emr_cluster" "cluster" {
 
   configurations_json = var.use_mysql_hive_metastore == true ? local.configurations_mysql_json : local.configurations_glue_json
 
+
+  bootstrap_action {
+    path = "file:/bin/echo"
+    name = "Dummy bootstrap action to track the md5 hash of the configuration json and redeploy only when changed"
+    args = [md5(var.use_mysql_hive_metastore == true ? local.configurations_mysql_json : local.configurations_glue_json)]
+  }
+
   bootstrap_action {
     name = "get-dks-cert"
     path = format("s3://%s/%s", aws_s3_bucket.emr.id, aws_s3_bucket_object.get_dks_cert_sh.key)
@@ -148,7 +155,7 @@ resource "aws_emr_cluster" "cluster" {
 
   lifecycle {
     ignore_changes = [
-      ec2_attributes
+      ec2_attributes, configurations_json
     ]
   }
 }


### PR DESCRIPTION
Tested on dev: 
- if there are no changes to `configurations_json` terraform shows empty plan 
- changes to `configurations_json` cause the cluster to be redeployed