### PR TITLE
remove use of random GUID as name

### DIFF
--- a/terraform/modules/emr/configuration_security.tf
+++ b/terraform/modules/emr/configuration_security.tf
@@ -98,7 +98,7 @@ locals {
 
 resource "aws_emr_security_configuration" "analytical_env_emrfs_em" {
   depends_on    = [aws_iam_policy.group_hive_data_access_policy]
-  name          = "analytical_env_${md5(jsonencode(local.emrfs_em))}"
+  name          = "analytical_env_${var.environment}"
   configuration = jsonencode(local.emrfs_em)
 
   provisioner "local-exec" {

--- a/terraform/modules/emr/configuration_security.tf
+++ b/terraform/modules/emr/configuration_security.tf
@@ -109,7 +109,7 @@ resource "aws_emr_security_configuration" "analytical_env_emrfs_em" {
 
 resource "aws_emr_security_configuration" "batch_emrfs_em" {
   depends_on    = [aws_iam_policy.group_hive_data_access_policy]
-  name          = "batch_${md5(jsonencode(local.batch_emrfs_em))}"
+  name          = "batch_${var.environment}"
   configuration = jsonencode(local.batch_emrfs_em)
 
   provisioner "local-exec" {


### PR DESCRIPTION
Remove use of random GUID as security config name.  Trade for whatever env it's in.  Should stop requiring a forced redeployment every time TF is ran.