### PR TITLE
Stop ae clusters

### DIFF
--- a/aviator.yml
+++ b/aviator.yml
@@ -26,6 +26,8 @@ spruce:
         regexp: ".*yml"
       - with_in: ci/aws-analytical-env/jobs/ami-test/
         regexp: ".*yml"
+      - with_in: ci/aws-analytical-env/jobs/admin/
+        regexp: ".*yml"
       - with_in: ci/aws-analytical-env/shared/
         regexp: ".*yml"
         except:

--- a/ci/aws-analytical-env/jobs/admin/dev-stop.yml
+++ b/ci/aws-analytical-env/jobs/admin/dev-stop.yml
@@ -8,4 +8,3 @@ jobs:
         config:
           params:
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.development)):role/ci
-            SNAPSHOT_TYPE: "full"

--- a/ci/aws-analytical-env/jobs/admin/dev-stop.yml
+++ b/ci/aws-analytical-env/jobs/admin/dev-stop.yml
@@ -1,5 +1,5 @@
 jobs:
-  - name: dev-stop-clusters
+  - name: dev-stop-cluster
     plan:
       - get: aws-analytical-env
         trigger: false

--- a/ci/aws-analytical-env/jobs/admin/dev-stop.yml
+++ b/ci/aws-analytical-env/jobs/admin/dev-stop.yml
@@ -1,0 +1,11 @@
+jobs:
+  - name: dev-stop-clusters
+    plan:
+      - get: aws-analytical-env
+        trigger: false
+      - .: (( inject meta.plan.stop-cluster ))
+        task: stop-clusters
+        config:
+          params:
+            AWS_ROLE_ARN: arn:aws:iam::((aws_account.development)):role/ci
+            SNAPSHOT_TYPE: "full"

--- a/ci/aws-analytical-env/jobs/admin/int-stop.yml
+++ b/ci/aws-analytical-env/jobs/admin/int-stop.yml
@@ -1,0 +1,10 @@
+jobs:
+  - name: int-stop-clusters
+    plan:
+      - get: aws-analytical-env
+        trigger: false
+      - .: (( inject meta.plan.stop-cluster ))
+        task: stop-clusters
+        config:
+          params:
+            AWS_ROLE_ARN: arn:aws:iam::((aws_account.integration)):role/ci

--- a/ci/aws-analytical-env/jobs/admin/int-stop.yml
+++ b/ci/aws-analytical-env/jobs/admin/int-stop.yml
@@ -1,5 +1,5 @@
 jobs:
-  - name: int-stop-clusters
+  - name: int-stop-cluster
     plan:
       - get: aws-analytical-env
         trigger: false

--- a/ci/aws-analytical-env/jobs/admin/preprod-stop.yml
+++ b/ci/aws-analytical-env/jobs/admin/preprod-stop.yml
@@ -1,5 +1,5 @@
 jobs:
-  - name: preprod-stop-clusters
+  - name: preprod-stop-cluster
     plan:
       - get: aws-analytical-env
         trigger: false

--- a/ci/aws-analytical-env/jobs/admin/preprod-stop.yml
+++ b/ci/aws-analytical-env/jobs/admin/preprod-stop.yml
@@ -1,0 +1,10 @@
+jobs:
+  - name: preprod-stop-clusters
+    plan:
+      - get: aws-analytical-env
+        trigger: false
+      - .: (( inject meta.plan.stop-cluster ))
+        task: stop-clusters
+        config:
+          params:
+            AWS_ROLE_ARN: arn:aws:iam::((aws_account.preprod)):role/ci

--- a/ci/aws-analytical-env/jobs/admin/production-stop.yml
+++ b/ci/aws-analytical-env/jobs/admin/production-stop.yml
@@ -1,5 +1,5 @@
 jobs:
-  - name: production-stop-cluster
+  - name: prod-stop-cluster
     plan:
       - get: aws-analytical-env
         trigger: false

--- a/ci/aws-analytical-env/jobs/admin/production-stop.yml
+++ b/ci/aws-analytical-env/jobs/admin/production-stop.yml
@@ -1,5 +1,5 @@
 jobs:
-  - name: production-stop-clusters
+  - name: production-stop-cluster
     plan:
       - get: aws-analytical-env
         trigger: false

--- a/ci/aws-analytical-env/jobs/admin/production-stop.yml
+++ b/ci/aws-analytical-env/jobs/admin/production-stop.yml
@@ -1,0 +1,10 @@
+jobs:
+  - name: production-stop-clusters
+    plan:
+      - get: aws-analytical-env
+        trigger: false
+      - .: (( inject meta.plan.stop-cluster ))
+        task: stop-clusters
+        config:
+          params:
+            AWS_ROLE_ARN: arn:aws:iam::((aws_account.production)):role/ci

--- a/ci/aws-analytical-env/jobs/admin/qa-stop.yml
+++ b/ci/aws-analytical-env/jobs/admin/qa-stop.yml
@@ -1,5 +1,5 @@
 jobs:
-  - name: qa-stop-clusters
+  - name: qa-stop-cluster
     plan:
       - get: aws-analytical-env
         trigger: false

--- a/ci/aws-analytical-env/jobs/admin/qa-stop.yml
+++ b/ci/aws-analytical-env/jobs/admin/qa-stop.yml
@@ -1,0 +1,10 @@
+jobs:
+  - name: qa-stop-clusters
+    plan:
+      - get: aws-analytical-env
+        trigger: false
+      - .: (( inject meta.plan.stop-cluster ))
+        task: stop-clusters
+        config:
+          params:
+            AWS_ROLE_ARN: arn:aws:iam::((aws_account.qa)):role/ci

--- a/ci/aws-analytical-env/jobs/terminate-cluster/stop_dev.yml
+++ b/ci/aws-analytical-env/jobs/terminate-cluster/stop_dev.yml
@@ -1,9 +1,9 @@
 jobs:
-  - name: dev-stop-cluster
+  - name: dev-stop-batch-cluster
     plan:
       - get: aws-analytical-env
         trigger: false
-      - .: (( inject meta.plan.stop-cluster ))
+      - .: (( inject meta.plan.stop-batch-cluster ))
         config:
           params:
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.development)):role/ci

--- a/ci/aws-analytical-env/jobs/terminate-cluster/stop_int.yml
+++ b/ci/aws-analytical-env/jobs/terminate-cluster/stop_int.yml
@@ -1,9 +1,9 @@
 jobs:
-  - name: int-stop-cluster
+  - name: int-stop-batch-cluster
     plan:
       - get: aws-analytical-env
         trigger: false
-      - .: (( inject meta.plan.stop-cluster ))
+      - .: (( inject meta.plan.stop-batch-cluster ))
         config:
           params:
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.integration)):role/ci

--- a/ci/aws-analytical-env/jobs/terminate-cluster/stop_preprod.yml
+++ b/ci/aws-analytical-env/jobs/terminate-cluster/stop_preprod.yml
@@ -1,9 +1,9 @@
 jobs:
-  - name: preprod-stop-cluster
+  - name: preprod-stop-batch-cluster
     plan:
       - get: aws-analytical-env
         trigger: false
-      - .: (( inject meta.plan.stop-cluster ))
+      - .: (( inject meta.plan.stop-batch-cluster ))
         config:
           params:
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.preprod)):role/ci

--- a/ci/aws-analytical-env/jobs/terminate-cluster/stop_prod.yml
+++ b/ci/aws-analytical-env/jobs/terminate-cluster/stop_prod.yml
@@ -1,9 +1,9 @@
 jobs:
-  - name: prod-stop-cluster
+  - name: prod-stop-batch-cluster
     plan:
       - get: aws-analytical-env
         trigger: false
-      - .: (( inject meta.plan.stop-cluster ))
+      - .: (( inject meta.plan.stop-batch-cluster ))
         config:
           params:
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.production)):role/ci

--- a/ci/aws-analytical-env/jobs/terminate-cluster/stop_qa.yml
+++ b/ci/aws-analytical-env/jobs/terminate-cluster/stop_qa.yml
@@ -1,9 +1,9 @@
 jobs:
-  - name: qa-stop-cluster
+  - name: qa-stop-batch-cluster
     plan:
       - get: aws-analytical-env
         trigger: false
-      - .: (( inject meta.plan.stop-cluster ))
+      - .: (( inject meta.plan.stop-batch-cluster ))
         config:
           params:
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.qa)):role/ci

--- a/ci/aws-analytical-env/shared/groups.yml
+++ b/ci/aws-analytical-env/shared/groups.yml
@@ -143,7 +143,23 @@ groups:
       - sync-cognito-users-to-rds-production
       - create-roles-and-munged-policies-production
 
-  - name: terminate-cluster
+  - name: admin-stop-batch-cluster
+    jobs:
+      - dev-stop-batch-cluster
+      - qa-stop-batch-cluster
+      - int-stop-batch-cluster
+      - preprod-stop-batch-cluster
+      - prod-stop-batch-cluster
+
+  - name: update-pipeline
+    jobs:
+      - update-pipeline
+
+  - name: ami-test
+    jobs:
+      - apply-and-test-with-ami
+  
+  - name: admin-stop-cluster
     jobs:
       - dev-stop-cluster
       - dev-stop-waiting
@@ -155,11 +171,3 @@ groups:
       - preprod-stop-waiting
       - prod-stop-cluster
       - prod-stop-waiting
-
-  - name: update-pipeline
-    jobs:
-      - update-pipeline
-
-  - name: ami-test
-    jobs:
-      - apply-and-test-with-ami

--- a/ci/aws-analytical-env/shared/meta.yml
+++ b/ci/aws-analytical-env/shared/meta.yml
@@ -577,8 +577,8 @@ meta:
               AWS_PUBLISHED_BUCKET="$(cat terraform-output-common-crown/outputs.json |  jq -r '.published_bucket.value.id')"
               aws s3 --endpoint-url=https://s3-eu-west-1.amazonaws.com sync files/ s3://${AWS_PUBLISHED_BUCKET}/${S3_FOLDER}
 
-    stop-cluster:
-      task: stop-cluster
+    stop-batch-cluster:
+      task: stop-batch-cluster
       config:
         platform: linux
         image_resource:
@@ -746,3 +746,33 @@ meta:
         inputs:
           - name: meta
           - name: emr-al2-ami
+
+
+    stop-cluster:
+      task: stop-cluster
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: ((dataworks.docker_awscli_repository))
+            version: ((dataworks.docker_awscli_version))
+            tag: ((dataworks.docker_awscli_version))
+        params:
+          AWS_ROLE_ARN: arn:aws:iam::((aws_account.management)):role/ci
+          AWS_DEFAULT_REGION: ((dataworks.aws_region))
+        run:
+          path: sh
+          args:
+            - -exc
+            - |
+              export AWS_DEFAULT_REGION
+              source /assume-role
+              set +x
+
+              echo "Stopping clusters for ${SNAPSHOT_TYPE}"
+              for CLUSTER_ID in $(aws emr list-clusters --active | jq -r '.Clusters[] | select(.Name | test("aws-analytical-env")) | .Id');
+              do
+                echo "Stopping cluster with id of ${CLUSTER_ID}"
+                aws emr terminate-clusters --cluster-ids $CLUSTER_ID
+              done

--- a/ci/aws-analytical-env/shared/meta.yml
+++ b/ci/aws-analytical-env/shared/meta.yml
@@ -770,7 +770,6 @@ meta:
               source /assume-role
               set +x
 
-              echo "Stopping clusters for ${SNAPSHOT_TYPE}"
               for CLUSTER_ID in $(aws emr list-clusters --active | jq -r '.Clusters[] | select(.Name | test("aws-analytical-env")) | .Id');
               do
                 echo "Stopping cluster with id of ${CLUSTER_ID}"


### PR DESCRIPTION
- Added admin job to stop `aws-analytical-env` clusters
- renamed jobs stopping `batch` clusters to include `batch` in name
- moved jobs that terminate clusters stuck in `waiting` to the  `aws-analytical-env` admin group.