### PR TITLE
changed sync to copy

### DIFF
--- a/ci/aws-analytical-env/shared/meta.yml
+++ b/ci/aws-analytical-env/shared/meta.yml
@@ -575,7 +575,7 @@ meta:
             - -exc
             - |
               AWS_PUBLISHED_BUCKET="$(cat terraform-output-common-crown/outputs.json |  jq -r '.published_bucket.value.id')"
-              aws s3 --endpoint-url=https://s3-eu-west-1.amazonaws.com cp files/ s3://${AWS_PUBLISHED_BUCKET}/${S3_FOLDER} . --recursive
+              aws s3 --endpoint-url=https://s3-eu-west-1.amazonaws.com cp files/ s3://${AWS_PUBLISHED_BUCKET}/${S3_FOLDER} --recursive
 
     stop-batch-cluster:
       task: stop-batch-cluster

--- a/ci/aws-analytical-env/shared/meta.yml
+++ b/ci/aws-analytical-env/shared/meta.yml
@@ -575,7 +575,7 @@ meta:
             - -exc
             - |
               AWS_PUBLISHED_BUCKET="$(cat terraform-output-common-crown/outputs.json |  jq -r '.published_bucket.value.id')"
-              aws s3 --endpoint-url=https://s3-eu-west-1.amazonaws.com cp files/ s3://${AWS_PUBLISHED_BUCKET}/${S3_FOLDER}
+              aws s3 --endpoint-url=https://s3-eu-west-1.amazonaws.com cp files/ s3://${AWS_PUBLISHED_BUCKET}/${S3_FOLDER} . --recursive
 
     stop-batch-cluster:
       task: stop-batch-cluster

--- a/ci/aws-analytical-env/shared/meta.yml
+++ b/ci/aws-analytical-env/shared/meta.yml
@@ -575,7 +575,7 @@ meta:
             - -exc
             - |
               AWS_PUBLISHED_BUCKET="$(cat terraform-output-common-crown/outputs.json |  jq -r '.published_bucket.value.id')"
-              aws s3 --endpoint-url=https://s3-eu-west-1.amazonaws.com sync files/ s3://${AWS_PUBLISHED_BUCKET}/${S3_FOLDER}
+              aws s3 --endpoint-url=https://s3-eu-west-1.amazonaws.com cp files/ s3://${AWS_PUBLISHED_BUCKET}/${S3_FOLDER}
 
     stop-batch-cluster:
       task: stop-batch-cluster


### PR DESCRIPTION
Since reusing same user_tables_migration folder for migration, changed sync to copy otherwise using sync will fill-up edge01 is high volume file.
 





1:49
so one directional copy would be better option.