### PR TITLE
Resolve EMR scheduled lambda issues

### DIFF
--- a/terraform/modules/emr/iam.tf
+++ b/terraform/modules/emr/iam.tf
@@ -878,7 +878,7 @@ data "aws_iam_policy_document" "assume_role_lambda" {
   }
 }
 
-data aws_iam_policy_document policy_logs_emr_scheduled_scaling {
+data "aws_iam_policy_document" "policy_logs_emr_scheduled_scaling" {
   statement {
     sid = "AllowLambdaCreateLogs"
     actions = [
@@ -891,13 +891,13 @@ data aws_iam_policy_document policy_logs_emr_scheduled_scaling {
   }
 }
 
-resource aws_iam_role_policy role_policy_emr_scheduled_scaling_logs {
+resource "aws_iam_role_policy" "role_policy_emr_scheduled_scaling_logs" {
   name   = "Role-Policy-EMR-Scheduled-Scaling-Logs"
   role   = aws_iam_role.emr_scheduled_scaling_role.id
   policy = data.aws_iam_policy_document.policy_logs_emr_scheduled_scaling.json
 }
 
-data aws_iam_policy_document policy_emr_scheduled_scaling_put_autoscaling_policy {
+data "aws_iam_policy_document" "policy_emr_scheduled_scaling_put_autoscaling_policy" {
   statement {
     sid = "AllowLambdaPutAutoscalingPolicy"
     actions = [
@@ -908,7 +908,7 @@ data aws_iam_policy_document policy_emr_scheduled_scaling_put_autoscaling_policy
   }
 }
 
-resource aws_iam_role_policy role_policy_emr_scheduled_scaling_put {
+resource "aws_iam_role_policy" "role_policy_emr_scheduled_scaling_put" {
   name   = "Role-Policy-EMR-Scheduled-Scaling-Put"
   role   = aws_iam_role.emr_scheduled_scaling_role.id
   policy = data.aws_iam_policy_document.policy_emr_scheduled_scaling_put_autoscaling_policy.json

--- a/terraform/modules/emr/iam.tf
+++ b/terraform/modules/emr/iam.tf
@@ -866,6 +866,11 @@ resource "aws_iam_role" "emr_scheduled_scaling_role" {
   tags               = var.common_tags
 }
 
+resource "aws_iam_role_policy_attachment" "emr_scheduled_scaling_basic_execution_policy_attachment" {
+  role       = aws_iam_role.emr_scheduled_scaling_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
 data "aws_iam_policy_document" "assume_role_lambda" {
   statement {
     sid     = "EMRScheduledScalingLambdaAssumeRole"

--- a/terraform/modules/emr/scheduled_scaling_lambda.tf
+++ b/terraform/modules/emr/scheduled_scaling_lambda.tf
@@ -33,7 +33,7 @@ resource "aws_lambda_function" "emr_scheduled_scaling" {
     }
   }
 
-  depends_on = [data.archive_file.emr_scheduled_scaling_lambda_zip]
+  depends_on = [data.archive_file.emr_scheduled_scaling_lambda_zip, aws_cloudwatch_log_group.emr_scheduled_scaling_lambda_logs]
 }
 
 resource "aws_lambda_permission" "allow_cloudwatch_to_call_emr_scaling_up_lambda" {


### PR DESCRIPTION
Required IAM changes to resolve lambda being unable to log out to log group.
Signed-off-by: Connor Avery <ConnorAvery@digital.uc.dwp.gov.uk>