### PR TITLE
AWS SQS added to VPC Endpoint service

### DIFF
--- a/terraform/deploy/infra/modules.tf
+++ b/terraform/deploy/infra/modules.tf
@@ -12,6 +12,7 @@ module analytical_env_vpc {
 
   aws_vpce_services = [
     "dynamodb",
+    "sqs",
     "ecs",
     "ecs-agent",
     "ecs-telemetry",


### PR DESCRIPTION
AWS SQS added to VPC Endpoint service to allow Azkaban sending messages to DataEgress SQS Queue.