### PR TITLE
Allow EMR to CRUD the alarms it creates for cluster autoscaling policies

### DIFF
--- a/terraform/modules/emr/iam.tf
+++ b/terraform/modules/emr/iam.tf
@@ -137,6 +137,19 @@ data "aws_iam_policy_document" "elastic_map_reduce_role" {
   }
 
   statement {
+    sid    = "AllowEmrToCreateDeleteAlarmsForEMROnly"
+    effect = "Allow"
+    actions = [
+      "cloudwatch:PutMetricAlarm",
+      "cloudwatch:DescribeAlarms",
+      "cloudwatch:DeleteAlarms",
+    ]
+    resources = [
+      "arn:aws:cloudwatch:${var.region}:${var.account}:alarm:j-*"
+    ]
+  }
+
+  statement {
     sid    = "AllowEmrToUseSpecificKMSKeys"
     effect = "Allow"
     actions = [


### PR DESCRIPTION
The alarms are named after the cluster, so specifying `j-` for the cluster ID will isolate the impact of any deletions to only alarms named after clusters. In other words, no alarms created by ourselves for monitoring.

Signed-off-by: Connor Avery <ConnorAvery@digital.uc.dwp.gov.uk>