### PR TITLE
Use a local value for subnet selection - Easier to refer to in runbook

### DIFF
--- a/terraform/modules/emr/emr.tf
+++ b/terraform/modules/emr/emr.tf
@@ -13,7 +13,7 @@ resource "aws_emr_cluster" "cluster" {
   custom_ami_id                     = var.ami_id
 
   ec2_attributes {
-    subnet_id                         = var.vpc.aws_subnets_private[0].id
+    subnet_id                         = local.emr_cluster_subnet_id
     additional_master_security_groups = aws_security_group.emr.id
     additional_slave_security_groups  = aws_security_group.emr.id
     emr_managed_master_security_group = aws_security_group.emr_master_private.id

--- a/terraform/modules/emr/local.tf
+++ b/terraform/modules/emr/local.tf
@@ -230,5 +230,7 @@ locals {
   aws_defaut_region                    = "eu-west-2"
   cw_agent_step_log_group_name         = "/app/analytical_batch/step_logs"
 
+  # Increment index of subnet to use an alternative AWS availability zone
+  emr_cluster_subnet_id = var.vpc.aws_subnets_private[0].id
 }
 


### PR DESCRIPTION
Signed-off-by: Connor Avery <ConnorAvery@digital.uc.dwp.gov.uk>