### PR TITLE
Livy EMR metrics lambda use all available subnets

### DIFF
--- a/terraform/modules/emr/emr.tf
+++ b/terraform/modules/emr/emr.tf
@@ -13,7 +13,7 @@ resource "aws_emr_cluster" "cluster" {
   custom_ami_id                     = var.ami_id
 
   ec2_attributes {
-    subnet_id                         = var.vpc.aws_subnets_private[0].id
+    subnet_id                         = local.emr_cluster_subnet_id
     additional_master_security_groups = aws_security_group.emr.id
     additional_slave_security_groups  = aws_security_group.emr.id
     emr_managed_master_security_group = aws_security_group.emr_master_private.id

--- a/terraform/modules/emr/local.tf
+++ b/terraform/modules/emr/local.tf
@@ -230,5 +230,7 @@ locals {
   aws_defaut_region                    = "eu-west-2"
   cw_agent_step_log_group_name         = "/app/analytical_batch/step_logs"
 
+  # Increment index of subnet to use an alternative AWS availability zone
+  emr_cluster_subnet_id = var.vpc.aws_subnets_private[0].id
 }
 

--- a/terraform/modules/testing/lambdas.tf
+++ b/terraform/modules/testing/lambdas.tf
@@ -41,7 +41,7 @@ resource "aws_lambda_function" "emr_metrics_lambda" {
   tags             = merge(var.common_tags, { Name = "${var.name_prefix}-livy-emr-metrics", ProtectSensitiveData = "True" })
   vpc_config {
     security_group_ids = [aws_security_group.metric_lambda.id]
-    subnet_ids         = [var.vpc.aws_subnets_private[0].id]
+    subnet_ids         = [var.vpc.aws_subnets_private[*].id]
   }
   environment {
     variables = {


### PR DESCRIPTION
The lambda will be able to connect to the EMR cluster regardless of subnet in the VPC.
Use all available subnets.